### PR TITLE
Reactivate the integration tests for remote file access (GCS, S3)

### DIFF
--- a/.github/workflows/dev-docker.yml
+++ b/.github/workflows/dev-docker.yml
@@ -5,8 +5,8 @@ env:
   DEFAULT_IMAGE_INCREMENT: 0
   DEFAULT_SERVER_REVISION: main
   DEFAULT_PYTHON_VERSIONS: 3.8 3.9 3.10 3.11 3.12 3.13
-  DEFAULT_KHIOPS_GCS_DRIVER_REVISION: 0.0.10
-  DEFAULT_KHIOPS_S3_DRIVER_REVISION: 0.0.12
+  DEFAULT_KHIOPS_GCS_DRIVER_REVISION: 0.0.11
+  DEFAULT_KHIOPS_S3_DRIVER_REVISION: 0.0.13
 on:
   pull_request:
     paths: [packaging/docker/khiopspydev/Dockerfile.*, .github/workflows/dev-docker.yml]
@@ -38,11 +38,11 @@ on:
         description: Khiops Server Revision
       khiops-gcs-driver-revision:
         type: string
-        default: 0.0.10
+        default: 0.0.11
         description: Driver version for Google Cloud Storage remote files
       khiops-s3-driver-revision:
         type: string
-        default: 0.0.12
+        default: 0.0.13
         description: Driver version for AWS-S3 remote files
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/dev-docker.yml
+++ b/.github/workflows/dev-docker.yml
@@ -5,6 +5,8 @@ env:
   DEFAULT_IMAGE_INCREMENT: 0
   DEFAULT_SERVER_REVISION: main
   DEFAULT_PYTHON_VERSIONS: 3.8 3.9 3.10 3.11 3.12 3.13
+  DEFAULT_KHIOPS_GCS_DRIVER_REVISION: 0.0.10
+  DEFAULT_KHIOPS_S3_DRIVER_REVISION: 0.0.12
 on:
   pull_request:
     paths: [packaging/docker/khiopspydev/Dockerfile.*, .github/workflows/dev-docker.yml]
@@ -34,6 +36,14 @@ on:
         type: string
         default: main
         description: Khiops Server Revision
+      khiops-gcs-driver-revision:
+        type: string
+        default: 0.0.10
+        description: Driver version for Google Cloud Storage remote files
+      khiops-s3-driver-revision:
+        type: string
+        default: 0.0.12
+        description: Driver version for AWS-S3 remote files
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
@@ -55,6 +65,8 @@ jobs:
           echo "KHIOPSDEV_OS_CODENAME=$(echo '${{ matrix.khiopsdev-os }}' | tr -d '0-9.')" >> "$GITHUB_ENV"
           echo "SERVER_REVISION=${{ inputs.server-revision || env.DEFAULT_SERVER_REVISION }}" >> "$GITHUB_ENV"
           echo "IMAGE_URL=ghcr.io/khiopsml/khiops-python/khiopspydev-${{ matrix.khiopsdev-os }}" >> "$GITHUB_ENV"
+          echo "KHIOPS_GCS_DRIVER_REVISION=${{ inputs.khiops-gcs-driver-revision || env.DEFAULT_KHIOPS_GCS_DRIVER_REVISION }}" >> "$GITHUB_ENV"
+          echo "KHIOPS_S3_DRIVER_REVISION=${{ inputs.khiops-s3-driver-revision || env.DEFAULT_KHIOPS_S3_DRIVER_REVISION }}" >> "$GITHUB_ENV"
       - name: Checkout khiops-python sources
         uses: actions/checkout@v4
       - name: Set up Docker Buildx
@@ -81,6 +93,9 @@ jobs:
       - name: Build image and push it to GitHub Container Registry
         uses: docker/build-push-action@v5
         with:
+          # Special hostname used by the integration tests for remote file access
+          # added using inputs because /etc/hosts is read-only for alternate builders (buildx via moby buildkit)
+          add-hosts: s3-bucket.localhost:127.0.0.1
           context: ./packaging/docker/khiopspydev/
           file: ./packaging/docker/khiopspydev/Dockerfile.${{ env.KHIOPSDEV_OS_CODENAME }}
           build-args: |
@@ -88,6 +103,8 @@ jobs:
             "KHIOPSDEV_OS=${{ matrix.khiopsdev-os }}"
             "SERVER_REVISION=${{ env.SERVER_REVISION }}"
             "PYTHON_VERSIONS=${{ inputs.python-versions || env.DEFAULT_PYTHON_VERSIONS }}"
+            "KHIOPS_GCS_DRIVER_REVISION=${{ env.KHIOPS_GCS_DRIVER_REVISION }}"
+            "KHIOPS_S3_DRIVER_REVISION=${{ env.KHIOPS_S3_DRIVER_REVISION }}"
           tags: ${{ env.DOCKER_IMAGE_TAGS }}
           # Push only on manual request
           push: ${{ inputs.push || false }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,11 +15,11 @@ on:
       khiops-desktop-revision:
         default: 10.2.4
         description: Khiops Windows Desktop Application Version
-      run-long-tests:
+      run-expensive-tests:
         type: boolean
         required: false
         default: false
-        description: Execute long tests
+        description: Execute expensive tests
   pull_request:
     paths:
       - khiops/**.py
@@ -110,8 +110,8 @@ jobs:
             rm -rf khiops.egg-info
           done
       - name: Prepare Unit Tests Environment
-        if: github.ref != 'dev' && github.ref != 'main' && ! inputs.run-long-tests
-        run: echo "UNITTEST_ONLY_SHORT_TESTS=true" >> "$GITHUB_ENV"
+        if: github.ref != 'dev' && github.ref != 'main' && ! inputs.run-expensive-tests
+        run: echo "SKIP_EXPENSIVE_TESTS=true" >> "$GITHUB_ENV"
       - name: Prepare Integration Tests on remote files
         env:
           AWS_ENDPOINT_URL: http://localhost:4569

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -133,10 +133,19 @@ jobs:
           cat  ${GITHUB_WORKSPACE}/.aws/credentials
           echo "Generated AWS configuration..."
           cat  ${GITHUB_WORKSPACE}/.aws/configuration
-
-          # Prepare GCS credentials
-          touch ${GITHUB_WORKSPACE}/google-credentials.json
           /scripts/run_fake_remote_file_servers.sh .  # launch the servers in the background
+      - name: Authenticate to GCP using "Workload Identity Federation"
+        # For integration tests on GCS we use a real Google account
+        # Retrieve the Google credentials through "Workload Identity Federation"
+        # see https://github.com/google-github-actions/auth?tab=readme-ov-file#workload-identity-federation-through-a-service-account
+        uses: google-github-actions/auth@v2
+        with:
+          service_account: khiops-gcs-driver-test-sa@ino-olr-dak-ideal-sbx.iam.gserviceaccount.com
+          workload_identity_provider: projects/322269704080/locations/global/workloadIdentityPools/github/providers/my-repo
+          # 'create_credentials_file' is true by default but let's make it explicit
+          # After authentication, the required GOOGLE_APPLICATION_CREDENTIALS environment variable is exported
+          # https://github.com/google-github-actions/auth?tab=readme-ov-file#inputs-miscellaneous
+          create_credentials_file: true
       - name: Run Unit & Integration Tests
         env:
           KHIOPS_SAMPLES_DIR: ${{ github.workspace }}/khiops-samples
@@ -150,19 +159,14 @@ jobs:
           # Oversubscribe for MPI > 4.x
           OMPI_MCA_rmaps_base_oversubscribe: true
           # for the tests with GCS
-          GCS_BUCKET_NAME: gcs-bucket
-          # we take advantage of the built-in `STORAGE_EMULATOR_HOST` env variable
-          # that every GCS client can read and lets us use a local fake file server
-          STORAGE_EMULATOR_HOST: http://localhost:4443
-          # even in GCS emulation mode, the credentials file must exist
-          GOOGLE_APPLICATION_CREDENTIALS: ${{ github.workspace }}/google-credentials.json
+          GCS_BUCKET_NAME: data-test-khiops-driver-gcs/khiops_data
           GCS_DRIVER_LOGLEVEL: info  # set to debug for diagnosis
-          S3_DRIVER_LOGLEVEL: info  # set to debug for diagnosis
           # for the tests with S3
+          S3_DRIVER_LOGLEVEL: info  # set to debug for diagnosis
           S3_BUCKET_NAME: s3-bucket
           AWS_SHARED_CREDENTIALS_FILE: ${{ github.workspace }}/.aws/credentials
           AWS_CONFIG_FILE: ${{ github.workspace }}/.aws/configuration
-          # common var for tests with GCS & S3
+          # Var for tests with S3
           no_proxy: localhost
         run: |
           # This is needed so that the Git tag is parsed and the khiops-python

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,5 +1,5 @@
 ---
-name: Unit Tests
+name: Tests
 env:
   DEFAULT_SAMPLES_REVISION: 10.2.4
   DEFAULT_KHIOPS_DESKTOP_REVISION: 10.2.4
@@ -112,7 +112,32 @@ jobs:
       - name: Prepare Unit Tests Environment
         if: github.ref != 'dev' && github.ref != 'main' && ! inputs.run-long-tests
         run: echo "UNITTEST_ONLY_SHORT_TESTS=true" >> "$GITHUB_ENV"
-      - name: Run Unit Tests
+      - name: Prepare Integration Tests on remote files
+        env:
+          AWS_ENDPOINT_URL: http://localhost:4569
+        shell: bash
+        run: |
+          # Prepare AWS-S3 credentials and configuration          
+          mkdir -p ${GITHUB_WORKSPACE}/.aws/
+          cat << EOF > ${GITHUB_WORKSPACE}/.aws/credentials
+          [default]
+          aws_access_key_id=KEY
+          aws_secret_access_key=SECRET           
+          EOF
+          cat << EOF > ${GITHUB_WORKSPACE}/.aws/configuration
+          [default]
+          endpoint_url=${AWS_ENDPOINT_URL}
+          region=eu-north-1          
+          EOF
+          echo "Generated AWS credentials..."
+          cat  ${GITHUB_WORKSPACE}/.aws/credentials
+          echo "Generated AWS configuration..."
+          cat  ${GITHUB_WORKSPACE}/.aws/configuration
+
+          # Prepare GCS credentials
+          touch ${GITHUB_WORKSPACE}/google-credentials.json
+          /scripts/run_fake_remote_file_servers.sh .  # launch the servers in the background
+      - name: Run Unit & Integration Tests
         env:
           KHIOPS_SAMPLES_DIR: ${{ github.workspace }}/khiops-samples
           KHIOPS_DOCKER_RUNNER_URL: https://localhost:11000
@@ -124,6 +149,21 @@ jobs:
           rmaps_base_oversubscribe: true
           # Oversubscribe for MPI > 4.x
           OMPI_MCA_rmaps_base_oversubscribe: true
+          # for the tests with GCS
+          GCS_BUCKET_NAME: gcs-bucket
+          # we take advantage of the built-in `STORAGE_EMULATOR_HOST` env variable
+          # that every GCS client can read and lets us use a local fake file server
+          STORAGE_EMULATOR_HOST: http://localhost:4443
+          # even in GCS emulation mode, the credentials file must exist
+          GOOGLE_APPLICATION_CREDENTIALS: ${{ github.workspace }}/google-credentials.json
+          GCS_DRIVER_LOGLEVEL: info  # set to debug for diagnosis
+          S3_DRIVER_LOGLEVEL: info  # set to debug for diagnosis
+          # for the tests with S3
+          S3_BUCKET_NAME: s3-bucket
+          AWS_SHARED_CREDENTIALS_FILE: ${{ github.workspace }}/.aws/credentials
+          AWS_CONFIG_FILE: ${{ github.workspace }}/.aws/configuration
+          # common var for tests with GCS & S3
+          no_proxy: localhost
         run: |
           # This is needed so that the Git tag is parsed and the khiops-python
           # version is retrieved
@@ -138,10 +178,10 @@ jobs:
             $CONDA run --no-capture-output -n "$CONDA_ENV" coverage report -m
             $CONDA run --no-capture-output -n "$CONDA_ENV" coverage xml -o "reports/$CONDA_ENV/py-coverage.xml"
           done
-      - name: Display Unit Test Reports
+      - name: Display Test Reports
         uses: dorny/test-reporter@v1
         with:
-          name: Unit Tests ${{ matrix.python-version }}
+          name: Run Tests ${{ matrix.python-version }}
           path: >-
             reports/py${{ matrix.python-version }}/TEST-tests.*.*.xml,
             reports/py${{ matrix.python-version }}_conda/TEST-tests.*.*.xml

--- a/khiops/core/internals/runner.py
+++ b/khiops/core/internals/runner.py
@@ -594,17 +594,26 @@ class KhiopsRunner(ABC):
 
         # Create the message reporting the errors and warnings
         error_msg = ""
-        errors, fatal_errors, warning_messages = self._collect_errors(log_file_path)
-        if warning_messages:
-            error_msg += "Warnings in log:\n" + "".join(warning_messages)
-        if errors:
-            if error_msg:
-                error_msg += "\n"
-            error_msg += "Errors in log:\n" + "".join(errors)
-        if fatal_errors:
-            if error_msg:
-                error_msg += "\n"
-            error_msg += "Fatal errors in log:\n" + "".join(fatal_errors)
+        # If the log file exists: Collect the errors and warnings messages
+        if fs.exists(log_file_path):
+            errors, fatal_errors, warning_messages = self._collect_errors(log_file_path)
+            if warning_messages:
+                error_msg += "Warnings in log:\n" + "".join(warning_messages)
+            if errors:
+                if error_msg:
+                    error_msg += "\n"
+                error_msg += "Errors in log:\n" + "".join(errors)
+            if fatal_errors:
+                if error_msg:
+                    error_msg += "\n"
+                error_msg += "Fatal errors in log:\n" + "".join(fatal_errors)
+        # Otherwise warn that the log file is missing
+        else:
+            warnings.warn(
+                f"Log file not found after {tool_name} execution."
+                f"Path: {log_file_path}"
+            )
+            errors = fatal_errors = []
 
         # Add stdout to the warning message if non empty
         if stdout:

--- a/packaging/conda/meta.yaml
+++ b/packaging/conda/meta.yaml
@@ -30,8 +30,12 @@ requirements:
     - pandas >=0.25.3
     - scikit-learn >=0.22.2
   run_constrained:
-    - boto3 >=1.17.39
+    # do not necessary use the latest version
+    # to avoid undesired breaking changes
+    - boto3 >=1.17.39,<=1.35.69
     - google-cloud-storage >=1.37.0
+    # an open issue on boto3 (https://github.com/boto/boto3/issues/3585) forces a min version of pyopenssl
+    - pyopenssl>=24.0.0,<25.0.0
 
 outputs:
   - name: {{ metadata.get('name') }}

--- a/packaging/docker/khiopspydev/Dockerfile.ubuntu
+++ b/packaging/docker/khiopspydev/Dockerfile.ubuntu
@@ -10,14 +10,15 @@ ARG KHIOPS_REVISION
 RUN true \
   # Install git (for khiops-python version calculation) and pip \
   && apt-get -y update \
-  && apt-get -y --no-install-recommends install git python3-pip zip pandoc wget \
+  && apt-get -y --no-install-recommends install git python3-pip zip pandoc wget ruby-dev \
   # Get Linux distribution codename \
   && if [ -f /etc/os-release ]; then . /etc/os-release; fi \
   # Obtain the Khiops native package \
   && KHIOPS_PKG_FILE=$KHIOPS_REVISION/khiops-core-openmpi_$KHIOPS_REVISION-1-$VERSION_CODENAME.amd64.deb \
   && wget -O KHIOPS_CORE.deb "https://github.com/KhiopsML/khiops/releases/download/${KHIOPS_PKG_FILE}" \
-  # Install the Khiops native package \
-  && dpkg -i --force-all KHIOPS_CORE.deb \
+  # Install the Khiops native package : make it always succeed. \
+  # If dpkg fails it is due to missing dependencies which will be installed by apt in the next line \
+  && (dpkg -i --force-all KHIOPS_CORE.deb || true) \
   && apt-get -f -y install \
   && rm -f KHIOPS_CORE.deb \
   # Set python to python3 \
@@ -53,10 +54,36 @@ RUN true \
   && true
 
 RUN mkdir -p /scripts
-COPY ./run_service.sh /scripts/run_service.sh
-RUN chmod +x /scripts/run_service.sh && \
+COPY ./run_service.sh ./run_fake_remote_file_servers.sh /scripts/
+RUN chmod +x /scripts/run_service.sh /scripts/run_fake_remote_file_servers.sh && \
   useradd -rm -d /home/ubuntu -s /bin/bash -g root -u 1000 ubuntu
 
+# new gcs & s3 drivers (written in C++)
+ARG KHIOPS_GCS_DRIVER_REVISION
+ARG KHIOPS_S3_DRIVER_REVISION
+RUN true \
+    && wget -O khiops-gcs.deb https://github.com/KhiopsML/khiopsdriver-gcs/releases/download/${KHIOPS_GCS_DRIVER_REVISION}/khiops-gcs_${KHIOPS_GCS_DRIVER_REVISION}.deb \
+    && wget -O khiops-s3.deb https://github.com/KhiopsML/khiopsdriver-s3/releases/download/${KHIOPS_S3_DRIVER_REVISION}/khiops-s3_${KHIOPS_S3_DRIVER_REVISION}.deb \
+    && (dpkg -i --force-all khiops-gcs.deb khiops-s3.deb || true) \
+    && apt-get -f -y install \
+    && rm -f khiops-gcs.deb khiops-s3.deb \
+    && true
+
 FROM ghcr.io/khiopsml/khiops-server:${SERVER_REVISION} AS server
+
 FROM khiopsdev AS base
 COPY --from=server /service /usr/bin/service
+
+# S3 fake file server (only in the ubuntu container)
+# Do not use the latest fakes3 version because starting from 1.3 a licence is required
+# if fakes3 is no longer compatible think about switching to an alternative and fully compatible server
+# (https://github.com/jamhall/s3rver:v3.7.1 is not yet for example)
+RUN gem install fakes3:1.2.1 sorted_set
+# Avoid resolving a fake s3-bucket.localhost hostname
+# Alternate builders (buildx via moby buildkit) mount /etc/hosts read-only, the following command will fail
+# echo "127.0.0.1 s3-bucket.localhost" >> /etc/hosts
+# You will have to add the `add-hosts` input instead (https://github.com/docker/build-push-action/#inputs)
+
+# Port on which fakes3 is listening
+EXPOSE 4569
+

--- a/packaging/docker/khiopspydev/Dockerfile.ubuntu
+++ b/packaging/docker/khiopspydev/Dockerfile.ubuntu
@@ -40,6 +40,8 @@ RUN true \
 # set up all the supported Python environments under conda (for the unit tests)
 # relying on a variable containing all the versions
 ARG PYTHON_VERSIONS
+ARG KHIOPS_GCS_DRIVER_REVISION
+ARG KHIOPS_S3_DRIVER_REVISION
 RUN true \
   && export CONDA="/root/miniforge3/bin/conda" \
   && /bin/bash -c 'for version in ${PYTHON_VERSIONS}; \
@@ -49,7 +51,12 @@ RUN true \
         do \
             $CONDA create -y -n $CONDA_ENV python=${version}; \
         done; \
+        # khiops core \
         $CONDA install -y -n py${version}_conda -c khiops-dev khiops-core=$(echo ${KHIOPS_REVISION} | tr -d "-") ; \
+        # remote files drivers installed in the conda environment \
+        $CONDA install -y -n py${version}_conda -c khiops \
+        khiops-driver-s3=${KHIOPS_S3_DRIVER_REVISION} \
+        khiops-driver-gcs=${KHIOPS_GCS_DRIVER_REVISION}; \
     done' \
   && true
 
@@ -58,12 +65,12 @@ COPY ./run_service.sh ./run_fake_remote_file_servers.sh /scripts/
 RUN chmod +x /scripts/run_service.sh /scripts/run_fake_remote_file_servers.sh && \
   useradd -rm -d /home/ubuntu -s /bin/bash -g root -u 1000 ubuntu
 
-# new gcs & s3 drivers (written in C++)
-ARG KHIOPS_GCS_DRIVER_REVISION
-ARG KHIOPS_S3_DRIVER_REVISION
+# remote files drivers installed system-wide
 RUN true \
-    && wget -O khiops-gcs.deb https://github.com/KhiopsML/khiopsdriver-gcs/releases/download/${KHIOPS_GCS_DRIVER_REVISION}/khiops-gcs_${KHIOPS_GCS_DRIVER_REVISION}.deb \
-    && wget -O khiops-s3.deb https://github.com/KhiopsML/khiopsdriver-s3/releases/download/${KHIOPS_S3_DRIVER_REVISION}/khiops-s3_${KHIOPS_S3_DRIVER_REVISION}.deb \
+    # Get Linux distribution codename \
+    && if [ -f /etc/os-release ]; then . /etc/os-release; fi \
+    && wget -O khiops-gcs.deb https://github.com/KhiopsML/khiopsdriver-gcs/releases/download/${KHIOPS_GCS_DRIVER_REVISION}/khiops-driver-gcs_${KHIOPS_GCS_DRIVER_REVISION}-1-${VERSION_CODENAME}.amd64.deb \
+    && wget -O khiops-s3.deb https://github.com/KhiopsML/khiopsdriver-s3/releases/download/${KHIOPS_S3_DRIVER_REVISION}/khiops-driver-s3_${KHIOPS_S3_DRIVER_REVISION}-1-${VERSION_CODENAME}.amd64.deb \
     && (dpkg -i --force-all khiops-gcs.deb khiops-s3.deb || true) \
     && apt-get -f -y install \
     && rm -f khiops-gcs.deb khiops-s3.deb \

--- a/packaging/docker/khiopspydev/run_fake_remote_file_servers.sh
+++ b/packaging/docker/khiopspydev/run_fake_remote_file_servers.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+ROOT_FOLDER=${1:-.} # defaults to current folder
+
+# File server for S3 (runs in background)
+# WARNING :
+# -r : exposes pre-provisioned files (not currently used feature) : the direct child folder will be the bucket name
+#      these files were uploaded once because fake-s3 creates metadata
+echo "Launching fakes3 in background..."
+PORT_NUMBER=${AWS_ENDPOINT_URL##*:}
+nohup /usr/local/bin/fakes3 \
+  -r "${ROOT_FOLDER}"/tests/resources/remote-access \
+  -p "${PORT_NUMBER}" > /dev/null < /dev/null 2>&1 & # needs to redirect all the 3 fds to free the TTY

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,14 @@ if __name__ == "__main__":
         ],
         cmdclass=versioneer.get_cmdclass(),
         extras_require={
-            "s3": ["boto3>=1.17.39"],
+            "s3": [
+                # do not necessary use the latest version
+                # to avoid undesired breaking changes
+                "boto3>=1.17.39,<=1.35.69",
+                # an open issue on boto3 (https://github.com/boto/boto3/issues/3585)
+                # forces a minimal version of pyopenssl
+                "pyopenssl>=24.0.0,<25.0.0",
+            ],
             "gcs": ["google-cloud-storage>=1.37.0"],
         },
     )

--- a/tests/test_helper.py
+++ b/tests/test_helper.py
@@ -272,10 +272,10 @@ class KhiopsTestHelper:
         return values
 
     @staticmethod
-    def skip_long_test(test_case):
-        if "UNITTEST_ONLY_SHORT_TESTS" in os.environ:
-            if os.environ["UNITTEST_ONLY_SHORT_TESTS"].lower() == "true":
-                test_case.skipTest("Skipping long test")
+    def skip_expensive_test(test_case):
+        if "SKIP_EXPENSIVE_TESTS" in os.environ:
+            if os.environ["SKIP_EXPENSIVE_TESTS"].lower() == "true":
+                test_case.skipTest("Skipping expensive test")
 
     @staticmethod
     def create_parameter_trace():

--- a/tests/test_khiops_integrations.py
+++ b/tests/test_khiops_integrations.py
@@ -177,6 +177,7 @@ class KhiopsRunnerEnvironmentTests(unittest.TestCase):
         #   directory
         # - check that the Khiops binary directory contains the MODL* binaries
         #   and `mpiexec` (which should be its default location)
+        conda_prefix = None
         if "CONDA_PREFIX" in os.environ:
             # Remove `CONDA_PREFIX/bin` from `PATH`
             conda_prefix_bin = os.path.join(os.environ["CONDA_PREFIX"], "bin")
@@ -186,11 +187,22 @@ class KhiopsRunnerEnvironmentTests(unittest.TestCase):
                 if path_fragment != conda_prefix_bin
             )
 
+            # Store existing CONDA_PREFIX
+            conda_prefix = os.environ["CONDA_PREFIX"]
+
             # Unset `CONDA_PREFIX`
             del os.environ["CONDA_PREFIX"]
 
         # Create a fresh local runner
         runner = KhiopsLocalRunner()
+
+        # Restore CONDA_PREFIX
+        if conda_prefix is not None:
+            os.environ["CONDA_PREFIX"] = conda_prefix
+
+            # Restore `CONDA_PREFIX/bin` into `PATH`
+            conda_prefix_bin = os.path.join(conda_prefix, "bin")
+            os.environ["PATH"] = os.pathsep.join([conda_prefix_bin, os.environ["PATH"]])
 
         # Check that MODL* files as set in the runner exist and are executable
         self.assertTrue(os.path.isfile(runner.khiops_path))

--- a/tests/test_khiops_integrations.py
+++ b/tests/test_khiops_integrations.py
@@ -223,7 +223,7 @@ class KhiopsMultitableFitTests(unittest.TestCase):
     """Test if Khiops estimator can be fitted on multi-table data"""
 
     def setUp(self):
-        KhiopsTestHelper.skip_long_test(self)
+        KhiopsTestHelper.skip_expensive_test(self)
 
     def test_estimator_multiple_create_and_fit_does_not_raise_exception(self):
         """Test if estimator can be fitted from paths several times"""

--- a/tests/test_parallel_execution.py
+++ b/tests/test_parallel_execution.py
@@ -28,7 +28,7 @@ class KhiopsParallelRunningTests(TestCase, KhiopsTestHelper):
     _n_cpus = -1
 
     def setUp(self):
-        KhiopsTestHelper.skip_long_test(self)
+        KhiopsTestHelper.skip_expensive_test(self)
 
     def _parallelise(self, callback, arg_sequence, n_cpus):
         """Parallelisation driver"""

--- a/tests/test_remote_access.py
+++ b/tests/test_remote_access.py
@@ -105,12 +105,7 @@ class KhiopsRemoteAccessTestsContainer:
             return ""
 
         def should_skip_in_a_conda_env(self):
-            """To be overriden by descendants
-
-            Temporarily skip the S3 and GCS tests in a conda environment
-            until the drivers for remote files access
-            are released as conda packages
-            """
+            """To be overriden by descendants"""
             return True
 
         def print_test_title(self):
@@ -145,11 +140,9 @@ class KhiopsRemoteAccessTestsContainer:
             ) == os.path.dirname(khiops_path)
 
         def setUp(self):
+
             self.skip_if_no_config()
             if self.is_in_a_conda_env() and self.should_skip_in_a_conda_env():
-                # TODO : Temporarily skip the test for Conda-installed khiops-core
-                #  until the drivers for remote files access
-                #  are released as conda packages
                 self.skipTest(
                     f"Remote test case {self.remote_access_test_case()} "
                     "in a conda environment is currently skipped"
@@ -322,6 +315,11 @@ class KhiopsS3RemoteFileTests(KhiopsRemoteAccessTestsContainer.KhiopsRemoteAcces
         if s3_config_exists():
             kh.get_runner().__init__()
 
+    def should_skip_in_a_conda_env(self):
+        # The S3 driver is now released for conda too.
+        # No need to skip the tests any longer in a conda environment
+        return False
+
     def config_exists(self):
         return s3_config_exists()
 
@@ -359,6 +357,11 @@ class KhiopsGCSRemoteFileTests(
         """Sets back the runner defaults"""
         if gcs_config_exists():
             kh.get_runner().__init__()
+
+    def should_skip_in_a_conda_env(self):
+        # The GCS driver is now released for conda too.
+        # No need to skip the tests any longer in a conda environment
+        return False
 
     def config_exists(self):
         return gcs_config_exists()

--- a/tests/test_remote_access.py
+++ b/tests/test_remote_access.py
@@ -84,6 +84,10 @@ class KhiopsRemoteAccessTestsContainer:
                     f"{proto}://{bucket_name}/khiops-cicd/samples/{file}",
                     os.path.join(kh.get_samples_dir(), file),
                 )
+                # symetric call to ensure the upload was OK
+                fs.copy_to_local(
+                    f"{proto}://{bucket_name}/khiops-cicd/samples/{file}", "/tmp/dummy"
+                )
 
         def results_dir_root(self):
             """To be overridden by descendants if needed

--- a/tests/test_remote_access.py
+++ b/tests/test_remote_access.py
@@ -140,6 +140,8 @@ class KhiopsRemoteAccessTestsContainer:
             ) == os.path.dirname(khiops_path)
 
         def setUp(self):
+            # Skip if only short and cheap tests are run
+            KhiopsTestHelper.skip_expensive_test(self)
 
             self.skip_if_no_config()
             if self.is_in_a_conda_env() and self.should_skip_in_a_conda_env():
@@ -221,8 +223,6 @@ class KhiopsRemoteAccessTestsContainer:
 
         def test_khiops_coclustering_with_remote_access(self):
             """Test the training of a khiops_coclustering with remote resources"""
-            # Skip if only short tests are run
-            KhiopsTestHelper.skip_long_test(self)
 
             # Setup paths
             # note : the current implementation forces the khiops.log file

--- a/tests/test_remote_access.py
+++ b/tests/test_remote_access.py
@@ -66,7 +66,7 @@ class KhiopsRemoteAccessTestsContainer:
 
         @classmethod
         def init_remote_bucket(cls, bucket_name=None, proto=None):
-            # create remote root_temp_dir
+            # create the remote root_temp_dir
             remote_resource = fs.create_resource(
                 f"{proto}://{bucket_name}/khiops-cicd/tmp"
             )
@@ -84,7 +84,7 @@ class KhiopsRemoteAccessTestsContainer:
                     f"{proto}://{bucket_name}/khiops-cicd/samples/{file}",
                     os.path.join(kh.get_samples_dir(), file),
                 )
-                # symetric call to ensure the upload was OK
+                # symmetric call to ensure the upload was OK
                 fs.copy_to_local(
                     f"{proto}://{bucket_name}/khiops-cicd/samples/{file}", "/tmp/dummy"
                 )
@@ -156,10 +156,22 @@ class KhiopsRemoteAccessTestsContainer:
                 )
             self.print_test_title()
 
+        def tearDown(self):
+            # Cleanup the output dir (the files within and the folder)
+            if hasattr(self, "folder_name_to_clean_in_teardown"):
+                for filename in fs.list_dir(self.folder_name_to_clean_in_teardown):
+                    fs.remove(
+                        fs.get_child_path(
+                            self.folder_name_to_clean_in_teardown, filename
+                        )
+                    )
+                fs.remove(self.folder_name_to_clean_in_teardown)
+
         def test_train_predictor_with_remote_access(self):
             """Test train_predictor with remote resources"""
             iris_data_dir = fs.get_child_path(kh.get_runner().samples_dir, "Iris")
-            output_dir = fs.get_child_path(
+            # ask for folder cleaning during tearDown
+            self.folder_name_to_clean_in_teardown = output_dir = fs.get_child_path(
                 self.results_dir_root(),
                 f"test_{self.remote_access_test_case()}_remote_files_{uuid.uuid4()}",
             )
@@ -176,22 +188,21 @@ class KhiopsRemoteAccessTestsContainer:
                 trace=True,
             )
 
-            # Check the existents of the trining files
+            # Check the existence of the training files
             self.assertTrue(fs.exists(fs.get_child_path(output_dir, "AllReports.khj")))
             self.assertTrue(fs.exists(fs.get_child_path(output_dir, "Modeling.kdic")))
 
-            # Cleanup
-            for filename in fs.list_dir(output_dir):
-                fs.remove(fs.get_child_path(output_dir, filename))
-
         def test_khiops_classifier_with_remote_access(self):
             """Test the training of a khiops_classifier with remote resources"""
+
             # Setup paths
             # note : the current implementation forces the khiops.log file
             # to be created in the output_dir (thus local)
             # (any attempt to override it as an arg
             # for the fit method will be ignored)
-            output_dir = (
+
+            # ask for folder cleaning during tearDown
+            self.folder_name_to_clean_in_teardown = output_dir = (
                 self._khiops_temp_dir + f"/KhiopsClassifier_output_dir_{uuid.uuid4()}/"
             )
             iris_data_dir = fs.get_child_path(kh.get_runner().samples_dir, "Iris")
@@ -215,10 +226,6 @@ class KhiopsRemoteAccessTestsContainer:
             predict_path = fs.get_child_path(output_dir, "predict.txt")
             self.assertTrue(fs.exists(predict_path), msg=f"Path: {predict_path}")
 
-            # Cleanup
-            for filename in fs.list_dir(output_dir):
-                fs.remove(fs.get_child_path(output_dir, filename))
-
         def test_khiops_coclustering_with_remote_access(self):
             """Test the training of a khiops_coclustering with remote resources"""
             # Skip if only short tests are run
@@ -229,7 +236,9 @@ class KhiopsRemoteAccessTestsContainer:
             # to be created in the output_dir (thus local)
             # (any attempt to override it as an arg
             # for the fit method will be ignored)
-            output_dir = (
+
+            # ask for folder cleaning during tearDown
+            self.folder_name_to_clean_in_teardown = output_dir = (
                 self._khiops_temp_dir
                 + f"/KhiopsCoclustering_output_dir_{uuid.uuid4()}/"
             )
@@ -262,6 +271,8 @@ class KhiopsRemoteAccessTestsContainer:
                 self._khiops_temp_dir, f"khiops_log_{uuid.uuid4()}.log"
             )
 
+            # no cleaning required as an exception would be raised
+            # without any result produced
             output_dir = fs.get_child_path(
                 self.results_dir_root(),
                 f"test_{self.remote_access_test_case()}_remote_files_{uuid.uuid4()}",

--- a/tests/test_remote_access.py
+++ b/tests/test_remote_access.py
@@ -453,8 +453,11 @@ class KhiopsDockerRunnerTests(KhiopsRemoteAccessTestsContainer.KhiopsRemoteAcces
 
         # Cleanup: remove directories created in `setUpClass`
         if docker_runner_config_exists():
-            shutil.rmtree(kh.get_runner().samples_dir)
-            shutil.rmtree(cls._khiops_temp_dir)
+
+            # If Khiops samples and temp dirs exist, remove them
+            with suppress(FileNotFoundError):
+                shutil.rmtree(kh.get_runner().samples_dir)
+                shutil.rmtree(cls._khiops_temp_dir)
 
         # Reset the Khiops Python runner to the initial one
         kh.set_runner(cls.initial_runner)

--- a/tests/test_samples.py
+++ b/tests/test_samples.py
@@ -16,7 +16,7 @@ class KhiopsSamplesTests(unittest.TestCase):
     """Test if all samples run without problems"""
 
     def setUp(self):
-        KhiopsTestHelper.skip_long_test(self)
+        KhiopsTestHelper.skip_expensive_test(self)
 
     def test_samples(self):
         """Test if all samples run without problems"""

--- a/tests/test_sklearn_output_types.py
+++ b/tests/test_sklearn_output_types.py
@@ -49,7 +49,7 @@ class KhiopsSklearnOutputTypes(unittest.TestCase):
     """Tests for checking the output types of predictors"""
 
     def setUp(self):
-        KhiopsTestHelper.skip_long_test(self)
+        KhiopsTestHelper.skip_expensive_test(self)
 
     def _replace(self, array, replacement_dict):
         return np.array([replacement_dict[value] for value in array])


### PR DESCRIPTION
Docker is installed in the khiopspydev docker image so that it can start the local fake servers .
The container must be started with the --privileged option otherwise docker inside the container would not start.
The fake servers are pre-provisioned with sample files to be ready before the tests run

closes https://github.com/KhiopsML/khiops-python/issues/175, https://github.com/KhiopsML/khiops-python/issues/53