### PR TITLE
When openmpi is launched with the quiet flag, the return code must be handled though

### DIFF
--- a/khiops/core/internals/runner.py
+++ b/khiops/core/internals/runner.py
@@ -891,6 +891,13 @@ class KhiopsRunner(ABC):
                     f"Khiops ended correctly but there were minor issues:\n{error_msg}"
                 )
                 warnings.warn(error_msg.rstrip())
+        else:
+            # no message available, an error must be raised though
+            if return_code != 0:
+                raise KhiopsRuntimeError(
+                    f"{tool_name} execution had errors (return code {return_code}) "
+                    "but no message is available\n"
+                )
 
     def _collect_errors(self, log_file_path):
         # Collect errors any errors found in the log


### PR DESCRIPTION
In version 10.2.2.4, openmpi is launched with the `--quiet` flag that shallows every error message.

It seems safe to remove this flag to give informative messages to the end user.
If the flag is to be kept the return code must be evaluated otherwise openmpi exits silently without letting the user know the issue (for example when the proc number is too high)