### PR TITLE
Stop setting OpenMPI-specific environment variable

### DIFF
--- a/khiops/core/internals/runner.py
+++ b/khiops/core/internals/runner.py
@@ -1025,13 +1025,6 @@ class KhiopsLocalRunner(KhiopsRunner):
                 "are needed. Khiops will run in a single process."
             )
 
-        if platform.system() == "Linux" and installation_method == "binary+pip":
-            # Set the OpenMPI variable OMPI_MCA_plm_rsh_agent to the empty string
-            # if not set
-            # This avoids errors on systems without ssh (eg. simple Docker containers)
-            if "OMPI_MCA_plm_rsh_agent" not in os.environ:
-                os.environ["OMPI_MCA_plm_rsh_agent"] = ""
-
         # Initialize the default samples dir
         self._initialize_default_samples_dir()
 


### PR DESCRIPTION
Thus, the invariant that only `khiops_env` sets all required environment for Khiops is observed.

Any variable that is necessary should be added to `khiops_env`. However, following tests, the `OMPI_MCA_plm_rsh_agent` does not seem to be needed anymore.