### PR TITLE
256 handle khiopsencoder edge case when there are no output features

### DIFF
--- a/khiops/utils/dataset.py
+++ b/khiops/utils/dataset.py
@@ -8,7 +8,6 @@
 import csv
 import io
 import json
-import os
 import warnings
 from abc import ABC, abstractmethod
 from collections.abc import Iterable, Mapping, Sequence

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ profile = "black"
 max-line-length = 88
 
 # Fail on errors and specific rules or if there are too many errors
-fail-on = ["E", "line-too-long", "unused-variable"]
+fail-on = ["E", "line-too-long", "unused-variable", "unused-import"]
 fail-under = 9.9
 
 [tool.pylint.messages_control]


### PR DESCRIPTION
commit f2fbf7228bc6f11fee0ce6148a19e312d36787c4 (HEAD -> 256-handle-khiopsencoder-edge-case-when-there-are-no-output-features, origin/256-handle-khiopsencoder-edge-case-when-there-are-no-output-features)
Author: Felipe Olmos <92923444+folmos-at-orange@users.noreply.github.com>
Date:   Wed Nov 6 16:58:32 2024 +0100

    Make unused-import pylint rule a failure

commit 43da1c1e97943cc7ac1555b287d0414d66467197
Author: Felipe Olmos <92923444+folmos-at-orange@users.noreply.github.com>
Date:   Wed Nov 6 14:49:48 2024 +0100

    Set KhiopsEncoder to "unfit" when there are no informative vars

    If there are no informative vars for `KhiopsEncoder` we declare the fit
    as a failed an undefine all attributes.

    Note that we use the sklearn convention that an estimator is fitted if
    and only if no attributes are defined. Estimator attributes are
    conventionally defined as public attributes whose name have a suffix
    `_`.

commit 853b10acca78ba0f3d5a64e58d24469d213022e3
Author: Felipe Olmos <92923444+folmos-at-orange@users.noreply.github.com>
Date:   Wed Nov 6 10:24:35 2024 +0100

    Fix KhiopsEstimator sklearn integration tests

    We do not skip anymore any of the sklearn.utils.estimator_checks for the
    KhiopsEstimator class. We just parametrize the instance so it always
    have a non-empty encoder.

    A non-empty encoder may happen with the MODL encoding when there are no
    informative variables.