### PR TITLE
Eliminate is_fitted_ sklearn attribute

### DIFF
--- a/tests/test_estimator_attributes.py
+++ b/tests/test_estimator_attributes.py
@@ -172,7 +172,6 @@ class EstimatorAttributesTests(unittest.TestCase):
             self.assertEqual(
                 model.n_features_used_, len(feature_used_importances_report)
             )
-        self.assertTrue(model.is_fitted_)
 
     def test_classifier_attributes_monotable(self):
         """Test consistency of KhiopsClassifier's attributes with the output reports

--- a/tests/test_sklearn.py
+++ b/tests/test_sklearn.py
@@ -11,8 +11,10 @@ import os
 import shutil
 import unittest
 import warnings
+from itertools import product
 
 import numpy as np
+from sklearn.exceptions import NotFittedError
 from sklearn.utils.estimator_checks import check_estimator
 from sklearn.utils.validation import NotFittedError, check_is_fitted
 
@@ -2704,3 +2706,25 @@ class KhiopsSklearnVariousTests(unittest.TestCase):
 
         # Check that the encoder is not fit
         self.assertNotFit(khe)
+
+    def test_export_operations_raise_when_not_fitted(self):
+        """Test that export functions raise NonFittedError exceptions when non-fitted
+
+        .. note:
+            The standard operations (predict, predict_proba, transform, etc) are
+            covered by KhiopsSklearnEstimatorStandardTests.
+        """
+        # Prepare the fixtures
+        export_operations = ["export_dictionary_file", "export_report_file"]
+        estimators = [
+            KhiopsClassifier(),
+            KhiopsRegressor(),
+            KhiopsEncoder(),
+            KhiopsCoclustering(),
+        ]
+
+        # Execute the tests
+        for export_operation, estimator in product(export_operations, estimators):
+            with self.subTest(export_operation=export_operation, estimator=estimator):
+                with self.assertRaises(NotFittedError):
+                    getattr(estimator, export_operation)("report.khj")


### PR DESCRIPTION
commit 720d30a52a3e24462b2c5bd8baed244d9e02425e (HEAD -> 273-eliminate-is_fitted_-sklearn-attribute, origin/273-eliminate-is_fitted_-sklearn-attribute)
Author: Felipe Olmos <92923444+folmos-at-orange@users.noreply.github.com>
Date:   Mon Nov 18 17:05:40 2024 +0100

    Add failure tests for export estimator operations

commit af1189513f21c2b4574fdb4d004154c007e41757
Author: Felipe Olmos <92923444+folmos-at-orange@users.noreply.github.com>
Date:   Mon Nov 18 16:42:04 2024 +0100

    Eliminate is_fitted_ sklearn attribute