### PR TITLE
294 prepare release 10231

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,13 @@
   - Example: 10.2.1.4 is the 5th version that supports khiops 10.2.1.
 - Internals: Changes in *Internals* sections are unlikely to be of interest for data scientists.
 
-## Unreleased
+## 10.2.3.1 - 2024-11-26
+
+### Added
+- (General) Support for Python 3.13.
+
+### Fixed
+- (General) Initialization failing in Conda-based environments.
 
 ### Changed
 - (`core`) Support for system parameters has been moved from the `KhiopsLocalRunner` to the `core` API.
@@ -14,7 +20,7 @@
 - (`core`) System parameter `khiops_temp_dir` has been renamed to `temp_dir`.
 
 ### Removed
-- (General) pyKhiops 9 compatibility code.
+- (General) Khiops Python 9 compatibility.
 
 ## 10.2.3.0 - 2024-11-13
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -9,6 +9,7 @@ Installation
 Khiops is better installed with `conda package manager <https://docs.conda.io/en/latest/>`_
 
 .. code-block:: shell
+
     conda install -c conda-forge -c khiops khiops
 
 More details and other install methods are documented at the `Khiops website

--- a/khiops/core/api.py
+++ b/khiops/core/api.py
@@ -724,9 +724,11 @@ def train_predictor(
         If this target value is specified then it guarantees the calculation of lift
         curves for it.
     snb_predictor : bool, default ``True``
-        If ``True`` it trains a Selective Naive Bayes predictor.
+        If ``True`` it trains a Selective Naive Bayes predictor. **Deprecated** will be
+        removed in Khiops 11.
     univariate_predictor_number : int, default 0
-        Number of univariate predictors to train.
+        Number of univariate predictors to train.**Deprecated** will be removed in
+        Khiops 11.
     map_predictor : bool, default ``False``
         If ``True`` trains a Maximum a Posteriori Naive Bayes predictor.
         **Deprecated** will be removed in Khiops Python 11.
@@ -762,23 +764,25 @@ def train_predictor(
     discretization_method : str
         Name of the discretization method. Its valid values depend on the task:
             - Supervised: "MODL" (default), "EqualWidth" or "EqualFrequency"
-            - Unsupervised: "EqualWidth" (default), "EqualFrequency" or  "None"
+            - Unsupervised: "EqualWidth" (default), "EqualFrequency" or "None"
     min_interval_frequency : int, default 0
         Minimum number of instances in an interval. If equal to 0 it is
-        automatically calculated.
+        automatically calculated. **Deprecated** will be removed in Khiops 11.
     max_intervals : int, default 0
         Maximum number of intervals to construct. If equal to 0 it is automatically
-        calculated.
+        calculated. **Deprecated** will be replaced by ``max_parts`` in Khiops 11.
     grouping_method : str
         Name of the grouping method. Its valid values depend on the task:
             - Supervised: "MODL" (default) or "BasicGrouping"
             - Unsupervised: "BasicGrouping" (default) or "None"
     min_group_frequency : int, default 0
-        Minimum number of instances for a group.
+        Minimum number of instances for a group. **Deprecated** will be removed in
+        Khiops 11.
     max_groups : int, default 0
         Maximum number of groups. If equal to 0 it is automatically calculated.
+        **Deprecated** will be replaced by ``max_parts`` in Khiops 11.
     results_prefix : str, default ""
-        Prefix of the result files.
+        Prefix of the result files. **Deprecated** will be removed in Khiops 11.
     ... :
         See :ref:`core-api-common-params`.
 
@@ -911,7 +915,7 @@ def evaluate_predictor(
         If this target value is specified then it guarantees the calculation of lift
         curves for it.
     results_prefix : str, default ""
-        Prefix of the result files.
+        Prefix of the result files. **Deprecated** will be removed in Khiops 11.
     ... :
         See :ref:`core-api-common-params`.
 
@@ -1083,14 +1087,14 @@ def train_recoder(
         substantially increase the training time.
     discretization_method : str
         Name of the discretization method. Its valid values depend on the task:
-            - Supervised: "MODL" (default), "EqualWidth" or "EqualFrequency".
-            - Unsupervised: "EqualWidth" (default), "EqualFrequency" or "None".
+            - Supervised: "MODL" (default), "EqualWidth" or "EqualFrequency"
+            - Unsupervised: "EqualWidth" (default), "EqualFrequency" or "None"
     min_interval_frequency : int, default 0
-        Minimum number of instances in an interval. If equal to 0 it is automatically
-        calculated.
+        Minimum number of instances in an interval. If equal to 0 it is
+        automatically calculated. **Deprecated** will be removed in Khiops 11.
     max_intervals : int, default 0
         Maximum number of intervals to construct. If equal to 0 it is automatically
-        calculated.
+        calculated. **Deprecated** will be replaced by ``max_parts`` in Khiops 11.
     informative_variables_only : bool, default ``True``
         If ``True`` keeps only informative variables.
     max_variables : int, default 0
@@ -1126,14 +1130,16 @@ def train_recoder(
             - "none": Keeps the variable as-is
     grouping_method : str
         Name of the grouping method. Its vaild values depend on the task:
-            - Supervised: "MODL" (default) or "BasicGrouping".
-            - Unsupervised: "BasicGrouping" (default) or "None".
+            - Supervised: "MODL" (default) or "BasicGrouping"
+            - Unsupervised: "BasicGrouping" (default) or "None"
     min_group_frequency : int, default 0
-        Minimum number of instances for a group.
+        Minimum number of instances for a group. **Deprecated** will be removed in
+        Khiops 11.
     max_groups : int, default 0
         Maximum number of groups. If equal to 0 it is automatically calculated.
+        **Deprecated** will be replaced by ``max_parts`` in Khiops 11.
     results_prefix : str, default ""
-        Prefix of the result files.
+        Prefix of the result files. **Deprecated** will be removed in Khiops 11.
     ... :
         See :ref:`core-api-common-params`.
 
@@ -1250,7 +1256,7 @@ def deploy_model(
         A dictionary containing the output data paths and file paths for a multi-table
         dictionary file. For more details see :doc:`/multi_table_primer`.
     results_prefix : str, default ""
-        Prefix of the result files.
+        Prefix of the result files. **Deprecated** will be removed in Khiops 11.
     ... :
         See :ref:`core-api-common-params`.
 
@@ -1549,7 +1555,7 @@ def train_coclustering(
     min_optimization_time : int, default 0
         Minimum optimization time in seconds.
     results_prefix : str, default ""
-        Prefix of the result files.
+        Prefix of the result files. **Deprecated** will be removed in Khiops 11.
     ... :
         See :ref:`core-api-common-params`.
 
@@ -1632,7 +1638,7 @@ def simplify_coclustering(
       Dictionary that associate variable names to their maximum number of parts to
       preserve in the simplified coclustering. If not set there is no limit.
     results_prefix : str, default ""
-        Prefix of the result files.
+        Prefix of the result files. **Deprecated** will be removed in Khiops 11.
     ... :
         See :ref:`core-api-common-params`.
 
@@ -1717,7 +1723,7 @@ def prepare_coclustering_deployment(
     variables_prefix : str, default ""
         Prefix for the variables in the deployment dictionary.
     results_prefix : str, default ""
-        Prefix of the result files.
+        Prefix of the result files. **Deprecated** will be removed in Khiops 11.
     ... :
         See :ref:`core-api-common-params`.
 


### PR DESCRIPTION
commit 6779bd1835fe6272a1fa79c5cb64ae01c328d90a (HEAD -> 294-prepare-release-10231, origin/294-prepare-release-10231)
Author: Felipe Olmos <92923444+folmos-at-orange@users.noreply.github.com>
Date:   Mon Nov 25 13:19:31 2024 +0100

    Update CHANGELOG.md

commit 5d47f9ef7bb32cdd877c3a011878ea3e38d8e0e0
Author: Felipe Olmos <92923444+folmos-at-orange@users.noreply.github.com>
Date:   Mon Nov 25 13:36:15 2024 +0100

    Add deprecated warnings in docstrings of core API

    These features were deprecated here: d7733ff.

commit 111eb0ae516e61617c5eb96a1d3b5d1a2aadbe2e
Author: Felipe Olmos <92923444+folmos-at-orange@users.noreply.github.com>
Date:   Mon Nov 25 14:12:32 2024 +0100

    Fix sphinx warning
---

### TODO Before Asking for a Review
- [x] Rebase your branch to the latest version of `dev` (or `main` for release PRs)
- [x] Make sure all CI workflows are green
- [x] When adding a public feature/fix: Update the `Unreleased` section of `CHANGELOG.md` (no date)
- [x] Self-Review: Review "Files Changed" tab and fix any problems you find
- API Docs (only if there are changes in docstrings, rst files or samples):
  - [x] Check the docs build **without** warning: see the log of the API Docs workflow
  - [x] Check that your changes render well in HTML: download the API Docs artifact and open `index.html`
  - If there are any problems it is faster to iterate by [building locally the API Docs](../blob/dev/doc/README.md#build-the-documentation)
