### PR TITLE
310 eliminate pair support from khiopsregressor

### DIFF
--- a/tests/test_estimator_attributes.py
+++ b/tests/test_estimator_attributes.py
@@ -214,7 +214,7 @@ class EstimatorAttributesTests(unittest.TestCase):
         adult_df = pd.read_csv(adult_dataset_path, sep="\t").sample(750)
         X = adult_df.drop("age", axis=1)
         y = adult_df["age"]
-        khr_adult = KhiopsRegressor(n_trees=0, n_pairs=5)
+        khr_adult = KhiopsRegressor(n_trees=0)
         with warnings.catch_warnings():
             warnings.filterwarnings(
                 action="ignore",

--- a/tests/test_sklearn.py
+++ b/tests/test_sklearn.py
@@ -1114,12 +1114,9 @@ class KhiopsSklearnParameterPassingTests(unittest.TestCase):
                                 "field_separator": "\t",
                                 "detect_format": False,
                                 "header_line": True,
-                                "max_pairs": 1,
                                 "max_trees": 0,
                                 "max_selected_variables": 1,
                                 "max_evaluated_variables": 3,
-                                "specific_pairs": [("age", "race")],
-                                "all_possible_pairs": False,
                                 "construction_rules": ["TableMode", "TableSelection"],
                                 "additional_data_tables": {},
                             }
@@ -1206,12 +1203,9 @@ class KhiopsSklearnParameterPassingTests(unittest.TestCase):
                                 "field_separator": "\t",
                                 "detect_format": False,
                                 "header_line": True,
-                                "max_pairs": 1,
                                 "max_trees": 0,
                                 "max_selected_variables": 1,
                                 "max_evaluated_variables": 3,
-                                "specific_pairs": [("age", "race")],
-                                "all_possible_pairs": False,
                                 "construction_rules": ["TableMode", "TableSelection"],
                                 "additional_data_tables": {},
                             }
@@ -1306,12 +1300,9 @@ class KhiopsSklearnParameterPassingTests(unittest.TestCase):
                                 "detect_format": False,
                                 "header_line": True,
                                 "max_constructed_variables": 10,
-                                "max_pairs": 1,
                                 "max_trees": 0,
                                 "max_selected_variables": 1,
                                 "max_evaluated_variables": 3,
-                                "specific_pairs": [],
-                                "all_possible_pairs": False,
                                 "construction_rules": ["TableMode", "TableSelection"],
                                 "additional_data_tables": {
                                     "SpliceJunction`SpliceJunctionDNA"
@@ -1416,12 +1407,9 @@ class KhiopsSklearnParameterPassingTests(unittest.TestCase):
                                 "detect_format": False,
                                 "header_line": True,
                                 "max_constructed_variables": 10,
-                                "max_pairs": 1,
                                 "max_trees": 0,
                                 "max_selected_variables": 1,
                                 "max_evaluated_variables": 3,
-                                "specific_pairs": [],
-                                "all_possible_pairs": False,
                                 "construction_rules": ["TableMode", "TableSelection"],
                                 "log_file_path": os.path.join(
                                     cls.output_dir, "khiops.log"
@@ -2407,11 +2395,8 @@ class KhiopsSklearnParameterPassingTests(unittest.TestCase):
             schema_type="monotable",
             source_type="dataframe",
             extra_estimator_kwargs={
-                "n_pairs": 1,
                 "n_selected_features": 1,
                 "n_evaluated_features": 3,
-                "specific_pairs": [("age", "race")],
-                "all_possible_pairs": False,
                 "construction_rules": ["TableMode", "TableSelection"],
             },
         )
@@ -2426,11 +2411,8 @@ class KhiopsSklearnParameterPassingTests(unittest.TestCase):
             schema_type="monotable",
             source_type="dataframe_xy",
             extra_estimator_kwargs={
-                "n_pairs": 1,
                 "n_selected_features": 1,
                 "n_evaluated_features": 3,
-                "specific_pairs": [("age", "race")],
-                "all_possible_pairs": False,
                 "construction_rules": ["TableMode", "TableSelection"],
             },
         )
@@ -2443,11 +2425,8 @@ class KhiopsSklearnParameterPassingTests(unittest.TestCase):
             schema_type="monotable",
             source_type="file_dataset",
             extra_estimator_kwargs={
-                "n_pairs": 1,
                 "n_selected_features": 1,
                 "n_evaluated_features": 3,
-                "specific_pairs": [("age", "race")],
-                "all_possible_pairs": False,
                 "construction_rules": ["TableMode", "TableSelection"],
             },
         )
@@ -2461,12 +2440,9 @@ class KhiopsSklearnParameterPassingTests(unittest.TestCase):
             source_type="dataframe",
             extra_estimator_kwargs={
                 "n_features": 10,
-                "n_pairs": 1,
                 "n_trees": 0,
                 "n_selected_features": 1,
                 "n_evaluated_features": 3,
-                "specific_pairs": [],
-                "all_possible_pairs": False,
                 "construction_rules": ["TableMode", "TableSelection"],
             },
         )
@@ -2480,12 +2456,9 @@ class KhiopsSklearnParameterPassingTests(unittest.TestCase):
             source_type="file_dataset",
             extra_estimator_kwargs={
                 "n_features": 10,
-                "n_pairs": 1,
                 "n_trees": 0,
                 "n_selected_features": 1,
                 "n_evaluated_features": 3,
-                "specific_pairs": [],
-                "all_possible_pairs": False,
                 "construction_rules": ["TableMode", "TableSelection"],
             },
         )


### PR DESCRIPTION
commit 3eb545cef17f538ac1c212650b996ca6ce8d38dc (HEAD -> 310-eliminate-pair-support-from-khiopsregressor, origin/310-eliminate-pair-support-from-khiopsregressor)
Author: Felipe Olmos <92923444+folmos-at-orange@users.noreply.github.com>
Date:   Thu Dec 12 15:57:24 2024 +0100

    Remove n_pairs parameter from KhiopsRegressor

    It was never supported.

commit 1ba74d2e82d3773afb3e407cee5f70cfd907b534
Author: Felipe Olmos <92923444+folmos-at-orange@users.noreply.github.com>
Date:   Thu Dec 12 15:56:51 2024 +0100

    Update pairs documentation

---

### TODO Before Asking for a Review
- [ ] Rebase your branch to the latest version of `dev` (or `main` for release PRs)
- [ ] Make sure all CI workflows are green
- [ ] When adding a public feature/fix: Update the `Unreleased` section of `CHANGELOG.md` (no date)
- [ ] Self-Review: Review "Files Changed" tab and fix any problems you find
- API Docs (only if there are changes in docstrings, rst files or samples):
  - [ ] Check the docs build **without** warning: see the log of the API Docs workflow
  - [ ] Check that your changes render well in HTML: download the API Docs artifact and open `index.html`
  - If there are any problems it is faster to iterate by [building locally the API Docs](../blob/dev/doc/README.md#build-the-documentation)
