### PR TITLE
312 accept types in internal csv reading function

### DIFF
--- a/doc/samples/samples_sklearn.rst
+++ b/doc/samples/samples_sklearn.rst
@@ -723,7 +723,7 @@ Samples
         keep_initial_variables=True,
         transform_type_categorical="part_id",
         transform_type_numerical="part_id",
-        transform_pairs="part_id",
+        transform_type_pairs="part_id",
     )
     khe.fit(X, y)
 

--- a/khiops/samples/samples_sklearn.ipynb
+++ b/khiops/samples/samples_sklearn.ipynb
@@ -865,7 +865,7 @@
     "    keep_initial_variables=True,\n",
     "    transform_type_categorical=\"part_id\",\n",
     "    transform_type_numerical=\"part_id\",\n",
-    "    transform_pairs=\"part_id\",\n",
+    "    transform_type_pairs=\"part_id\",\n",
     ")\n",
     "khe.fit(X, y)\n",
     "\n",

--- a/khiops/samples/samples_sklearn.py
+++ b/khiops/samples/samples_sklearn.py
@@ -761,7 +761,7 @@ def khiops_encoder_with_hyperparameters():
         keep_initial_variables=True,
         transform_type_categorical="part_id",
         transform_type_numerical="part_id",
-        transform_pairs="part_id",
+        transform_type_pairs="part_id",
     )
     khe.fit(X, y)
 

--- a/khiops/sklearn/estimators.py
+++ b/khiops/sklearn/estimators.py
@@ -2733,7 +2733,7 @@ class KhiopsEncoder(TransformerMixin, KhiopsSupervisedEstimator):
 
         See the documentation for the ``numerical_recoding_method`` parameter of the
         `~.api.train_recoder` function for more details.
-    transform_pairs: str, default "part_id"
+    transform_type_pairs : str, default "part_id"
         Type of transformation for bivariate features. Valid values:
             - "part_id"
             - "part_label"
@@ -2811,7 +2811,7 @@ class KhiopsEncoder(TransformerMixin, KhiopsSupervisedEstimator):
         keep_initial_variables=False,
         transform_type_categorical="part_id",
         transform_type_numerical="part_id",
-        transform_pairs="part_id",
+        transform_type_pairs="part_id",
         verbose=False,
         output_dir=None,
         auto_sort=True,
@@ -2835,7 +2835,7 @@ class KhiopsEncoder(TransformerMixin, KhiopsSupervisedEstimator):
         self.group_target_value = group_target_value
         self.transform_type_categorical = transform_type_categorical
         self.transform_type_numerical = transform_type_numerical
-        self.transform_pairs = transform_pairs
+        self.transform_type_pairs = transform_type_pairs
         self.informative_features_only = informative_features_only
         self.keep_initial_variables = keep_initial_variables
         self._khiops_model_prefix = "R_"
@@ -2892,12 +2892,12 @@ class KhiopsEncoder(TransformerMixin, KhiopsSupervisedEstimator):
             "conditional_info": "conditional info",
             None: "none",
         }
-        if self.transform_pairs not in _transform_types:
+        if self.transform_type_pairs not in _transform_types:
             raise ValueError(
-                "'transform_pairs' must be one of the following:"
+                "'transform_type_pairs' must be one of the following:"
                 ",".join(_transform_types.keys)
             )
-        return _transform_types[self.transform_pairs]
+        return _transform_types[self.transform_type_pairs]
 
     def _fit_check_params(self, ds, **kwargs):
         # Call parent method
@@ -2931,10 +2931,12 @@ class KhiopsEncoder(TransformerMixin, KhiopsSupervisedEstimator):
                 "transform_type_categorical and transform_type_numerical "
                 "cannot be both None with n_trees == 0."
             )
-        # Check 'transform_pairs' parameter
-        if not isinstance(self.transform_pairs, str):
+        # Check 'transform_type_pairs' parameter
+        if not isinstance(self.transform_type_pairs, str):
             raise TypeError(
-                type_error_message("transform_pairs", self.transform_pairs, str)
+                type_error_message(
+                    "transform_type_pairs", self.transform_type_pairs, str
+                )
             )
         self._pairs_transform_method()  # Raises ValueError if invalid
 
@@ -3036,7 +3038,7 @@ class KhiopsEncoder(TransformerMixin, KhiopsSupervisedEstimator):
 
         del kwargs["transform_type_categorical"]
         del kwargs["transform_type_numerical"]
-        del kwargs["transform_pairs"]
+        del kwargs["transform_type_pairs"]
         del kwargs["categorical_target"]
 
         return args, kwargs

--- a/tests/test_sklearn.py
+++ b/tests/test_sklearn.py
@@ -2267,7 +2267,7 @@ class KhiopsSklearnParameterPassingTests(unittest.TestCase):
                 "keep_initial_variables": False,
                 "transform_type_categorical": "part_id",
                 "transform_type_numerical": "part_id",
-                "transform_pairs": "part_id",
+                "transform_type_pairs": "part_id",
             },
         )
 
@@ -2291,7 +2291,7 @@ class KhiopsSklearnParameterPassingTests(unittest.TestCase):
                 "keep_initial_variables": False,
                 "transform_type_categorical": "part_id",
                 "transform_type_numerical": "part_id",
-                "transform_pairs": "part_id",
+                "transform_type_pairs": "part_id",
             },
         )
 
@@ -2313,7 +2313,7 @@ class KhiopsSklearnParameterPassingTests(unittest.TestCase):
                 "keep_initial_variables": False,
                 "transform_type_categorical": "part_id",
                 "transform_type_numerical": "part_id",
-                "transform_pairs": "part_id",
+                "transform_type_pairs": "part_id",
             },
         )
 
@@ -2336,7 +2336,7 @@ class KhiopsSklearnParameterPassingTests(unittest.TestCase):
                 "keep_initial_variables": False,
                 "transform_type_categorical": "part_id",
                 "transform_type_numerical": "part_id",
-                "transform_pairs": "part_id",
+                "transform_type_pairs": "part_id",
             },
         )
 
@@ -2359,7 +2359,7 @@ class KhiopsSklearnParameterPassingTests(unittest.TestCase):
                 "keep_initial_variables": False,
                 "transform_type_categorical": "part_id",
                 "transform_type_numerical": "part_id",
-                "transform_pairs": "part_id",
+                "transform_type_pairs": "part_id",
             },
         )
 


### PR DESCRIPTION
This will enable an easier implementation of #74 and #74 in #306. 

```
commit 149fb30b1ed6f7e6562d1405d38a02388c6a56dc (HEAD -> 312-accept-types-in-internal-csv-reading-function, origin/312-accept-types-in-internal-csv-reading-function)
Author: Felipe Olmos <92923444+folmos-at-orange@users.noreply.github.com>
Date:   Tue Dec 17 17:01:40 2024 +0100

    Control the types on sklearn internal read table

    This is done only for KhiopsClassifier and KhiopsRegressor. It is
    critical for KhiopsClassifier as it accepts many target types.

    For KhiopsEncoder and KhiopsCoclustering is less critical and for the
    first one it is very complex.

commit 69dce771f41cf2c88f2cd8f757752e9f09f43854
Author: Felipe Olmos <92923444+folmos-at-orange@users.noreply.github.com>
Date:   Tue Dec 17 17:05:22 2024 +0100

    Fix a pylint nit

commit 9fafd2acd433330a9caf9712ee5b67e986d4928c
Author: Felipe Olmos <92923444+folmos-at-orange@users.noreply.github.com>
Date:   Tue Dec 17 17:13:16 2024 +0100

    Rename transform_pairs parameter to transform_type_pairs
```

---

### TODO Before Asking for a Review
- [x] Rebase your branch to the latest version of `dev` (or `main` for release PRs)
- [x] Make sure all CI workflows are green
- [x] When adding a public feature/fix: Update the `Unreleased` section of `CHANGELOG.md` (no date)
- [x] Self-Review: Review "Files Changed" tab and fix any problems you find
- API Docs (only if there are changes in docstrings, rst files or samples):
  - [x] Check the docs build **without** warning: see the log of the API Docs workflow
  - [x] Check that your changes render well in HTML: download the API Docs artifact and open `index.html`
  - If there are any problems it is faster to iterate by [building locally the API Docs](../blob/dev/doc/README.md#build-the-documentation)
