### PR TITLE
Add dev v10 to protected branches conditions

### DIFF
--- a/.github/workflows/dev-docker.yml
+++ b/.github/workflows/dev-docker.yml
@@ -81,9 +81,9 @@ jobs:
       - name: Set up the Docker Image Tags
         run: |
           set -x
-          # Set latest only if requested and on "dev" or "main" branch
+          # Set latest only if requested and on "dev", "dev-v10" or "main" branch
           if [[ "${{ inputs.set-latest }}" == "true" &&
-                ("$GITHUB_REF_NAME" == "dev" || "$GITHUB_REF_NAME" == "main") ]]
+                ("$GITHUB_REF_NAME" == "dev" || "$GITHUB_REF_NAME" == "dev-v10" || "$GITHUB_REF_NAME" == "main") ]]
           then
             DOCKER_IMAGE_TAGS="$IMAGE_URL:latest,$IMAGE_URL:$KHIOPS_REVISION.$IMAGE_INCREMENT"
           else

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,7 @@ on:
       - tests/**.py
       - tests/resources/**
       - '!tests/resources/**.md'
-      - .github/workflows/unit-tests.yml
+      - .github/workflows/tests.yml
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
@@ -109,8 +109,8 @@ jobs:
             $CONDA install -y -n "$CONDA_ENV" `grep -v "^\[" khiops.egg-info/requires.txt`
             rm -rf khiops.egg-info
           done
-      - name: Prepare Unit Tests Environment
-        if: github.ref != 'dev' && github.ref != 'main' && ! inputs.run-expensive-tests
+      - name: Prepare Tests Environment
+        if: github.ref != 'dev' && github.rev != 'dev-v10' && github.ref != 'main' && ! inputs.run-expensive-tests
         run: echo "SKIP_EXPENSIVE_TESTS=true" >> "$GITHUB_ENV"
       - name: Prepare Integration Tests on remote files
         env:


### PR DESCRIPTION
Allow to push 'latest' Docker image on dev-v10 as well
Run expensive tests by default on dev-v10 as well

---

### TODO Before Asking for a Review
- [x] Rebase your branch to the latest version of `dev-v10` (or `main` for release PRs)
- [ ] Make sure all CI workflows are green
- [x] Self-Review: Review "Files Changed" tab and fix any problems you find

