### PR TITLE
Fix sklearn tree importances retrieval bug

### DIFF
--- a/khiops/sklearn/estimators.py
+++ b/khiops/sklearn/estimators.py
@@ -1435,7 +1435,11 @@ class KhiopsSupervisedEstimator(KhiopsEstimator):
         else:
             pair_feature_evaluated_names_ = []
             pair_feature_evaluated_levels_ = []
-        if "treePreparationReport" in self.model_report_.json_data:
+        if (
+            "treePreparationReport" in self.model_report_.json_data
+            and "variablesStatistics"
+            in self.model_report_.json_data["treePreparationReport"]
+        ):
             tree_preparation_report = self.model_report_.json_data[
                 "treePreparationReport"
             ]["variablesStatistics"]


### PR DESCRIPTION
When obtaining the tree feature KPIS we access the JSON report path `treePreparationReport.variablesStatistics`. If there are informative variables but no informative tree `variablesStatistics` is not defined. We didn't check that and it lead to a bug in this rare case.

---

### TODO Before Asking for a Review
- [x] Rebase your branch to the latest version of `dev` (or `main` for release PRs)
- [x] Make sure all CI workflows are green
- [ ] When adding a public feature/fix: Update the `Unreleased` section of `CHANGELOG.md` (no date)
- [x] Self-Review: Review "Files Changed" tab and fix any problems you find
- API Docs (only if there are changes in docstrings, rst files or samples):
  - [ ] Check the docs build **without** warning: see the log of the API Docs workflow
  - [ ] Check that your changes render well in HTML: download the API Docs artifact and open `index.html`
  - If there are any problems it is faster to iterate by [building locally the API Docs](../blob/dev/doc/README.md#build-the-documentation)
