### PR TITLE
Fix sklearn tree importances retrieval bug (backport v10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
 ### Added
 - (`sklearn`) Support for boolean and float targets in `KhiopsClassifier`.
 
+### Fixed
+- (`sklearn`) Crash when there were no informative trees in predictors.
+
 ## 10.3.0.0 - 2025-02-10
 
 ### Fixed

--- a/khiops/sklearn/estimators.py
+++ b/khiops/sklearn/estimators.py
@@ -1674,10 +1674,14 @@ class KhiopsSupervisedEstimator(KhiopsEstimator):
         else:
             pair_feature_evaluated_names_ = []
             pair_feature_evaluated_levels_ = []
-        if "treePreparationReport" in self.model_report_raw_:
-            tree_preparation_report = self.model_report_raw_["treePreparationReport"][
-                "variablesStatistics"
-            ]
+        if (
+            "treePreparationReport" in self.model_report_.json_data
+            and "variablesStatistics"
+            in self.model_report_.json_data["treePreparationReport"]
+        ):
+            tree_preparation_report = self.model_report_.json_data[
+                "treePreparationReport"
+            ]["variablesStatistics"]
             tree_feature_evaluated_names_ = [
                 tree_preparation_report[i]["name"]
                 for i in range(0, len(tree_preparation_report))


### PR DESCRIPTION
When obtaining the tree feature kpis we access the JSON report path `treePreparationReport.variablesStatistics`. If there are informative variables but no informative tree `variablesStatistics` is not defined. We didn't check that and it lead to a bug in this rare case.

---

### TODO Before Asking for a Review
- [X] Rebase your branch to the latest version of `dev` (or `main` for release PRs)
- [x] Make sure all CI workflows are green
- [X] When adding a public feature/fix: Update the `Unreleased` section of `CHANGELOG.md` (no date)
- [X] Self-Review: Review "Files Changed" tab and fix any problems you find
