### PR TITLE
Customize khiops python tutorial ref

### DIFF
--- a/.github/workflows/api-docs.yml
+++ b/.github/workflows/api-docs.yml
@@ -1,5 +1,7 @@
 ---
 name: API Docs
+env:
+  DEFAULT_KHIOPS_PYTHON_TUTORIAL_REVISION: main
 on:
   workflow_dispatch:
     inputs:
@@ -8,6 +10,9 @@ on:
         required: true
         type: boolean
         default: false
+      khiops-python-tutorial-revision:
+        default: main
+        description: khiops-python-tutorial repo revision
       image-tag:
         default: latest
         description: Development Docker Image Tag
@@ -44,6 +49,10 @@ jobs:
       # https://github.com/actions/runner/issues/2033#issuecomment-1598547465
       options: --user 1001
     steps:
+      - name: Set parameters as env
+        run: |
+          KHIOPS_PYTHON_TUTORIAL_REVISION=${{ inputs.khiops-python-tutorial-revision || env.DEFAULT_KHIOPS_PYTHON_TUTORIAL_REVISION }}
+          echo "KHIOPS_PYTHON_TUTORIAL_REVISION=$KHIOPS_PYTHON_TUTORIAL_REVISION" >> "$GITHUB_ENV"
       - name: Checkout khiops-python
         uses: actions/checkout@v4
         with:
@@ -52,6 +61,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: khiopsml/khiops-python-tutorial
+          ref: ${{ env.KHIOPS_PYTHON_TUTORIAL_REVISION }}
           path: doc/khiops-python-tutorial
       - name: Add pip scripts directory to path
         run: echo PATH="$PATH:/github/home/.local/bin" >> "$GITHUB_ENV"

--- a/.github/workflows/api-docs.yml
+++ b/.github/workflows/api-docs.yml
@@ -1,7 +1,7 @@
 ---
 name: API Docs
 env:
-  DEFAULT_KHIOPS_PYTHON_TUTORIAL_REVISION: main
+  DEFAULT_KHIOPS_PYTHON_TUTORIAL_REVISION: 10.3.1.0
 on:
   workflow_dispatch:
     inputs:
@@ -11,7 +11,7 @@ on:
         type: boolean
         default: false
       khiops-python-tutorial-revision:
-        default: main
+        default: 10.3.1.0
         description: khiops-python-tutorial repo revision
       image-tag:
         default: latest


### PR DESCRIPTION
Customize the Khiops Python tutorial reference tag. Thusly, we can have the tutorials build for V11 beta (default, on `main`), as well as for V10 (via specific `10.3.1.0` tag).

---

### TODO Before Asking for a Review
- [x] Rebase your branch to the latest version of `dev-v10` (or `main` for release PRs)
- [x] Make sure all CI workflows are green
- [x] Self-Review: Review "Files Changed" tab and fix any problems you find
- API Docs (only if there are changes in docstrings, rst files or samples):
  - [x] Check the docs build **without** warning: see the log of the API Docs workflow
  - ~[ ] Check that your changes render well in HTML: download the API Docs artifact and open `index.html`~ There are no changes to the documentation itself; checking that it builds without warnings suffices, as this shows that the correct `khiops-python-tutorial` revision has been checked out.
  - If there are any problems it is faster to iterate by [building locally the API Docs](../blob/dev/doc/README.md#build-the-documentation)
