### PR TITLE
415 build api documentation as release artifact instead of deploying it directly

### DIFF
--- a/.github/workflows/api-docs.yml
+++ b/.github/workflows/api-docs.yml
@@ -46,20 +46,10 @@ jobs:
       # https://github.com/actions/runner/issues/2033#issuecomment-1598547465
       options: --user 1001
     steps:
-      - name: Set parameters as env
-        run: |
-          KHIOPS_PYTHON_TUTORIAL_REVISION=${{ inputs.khiops-python-tutorial-revision || env.DEFAULT_KHIOPS_PYTHON_TUTORIAL_REVISION }}
-          echo "KHIOPS_PYTHON_TUTORIAL_REVISION=$KHIOPS_PYTHON_TUTORIAL_REVISION" >> "$GITHUB_ENV"
       - name: Checkout khiops-python
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Checkout khiops-python-tutorial
-        uses: actions/checkout@v4
-        with:
-          repository: khiopsml/khiops-python-tutorial
-          ref: ${{ env.KHIOPS_PYTHON_TUTORIAL_REVISION }}
-          path: doc/khiops-python-tutorial
       - name: Add pip scripts directory to path
         run: echo PATH="$PATH:/github/home/.local/bin" >> "$GITHUB_ENV"
       - name: Install doc build requirements
@@ -72,10 +62,12 @@ jobs:
           # Install the doc python requirements
           cd doc
           pip3 install -U -r requirements.txt
+      # Clone the Khiops Python tutorial repository while building the documentation
       - name: Build Sphinx Documentation
         run: |
           cd doc
-          ./create-doc -t
+          ./create-doc -t -d -g \
+          ${{ inputs.khiops-python-tutorial-revision || env.DEFAULT_KHIOPS_PYTHON_TUTORIAL_REVISION }}
       - name: Upload the docs as an artifact
         uses: actions/upload-artifact@v4
         with:

--- a/doc/create-doc
+++ b/doc/create-doc
@@ -7,17 +7,20 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 # Default parameter values
 TRANSFORM_NOTEBOOKS=""
 DOWNLOAD_REPO=""
-DEFAULT_KHIOPS_TUTORIAL_REPO_URL="git@github.com:KhiopsML/khiops-python-tutorial.git"
+DEFAULT_KHIOPS_TUTORIAL_REPO_URL="https://github.com/KhiopsML/khiops-python-tutorial.git"
+DEFAULT_KHIOPS_TUTORIAL_REPO_REF="main"
 DEFAULT_KHIOPS_TUTORIAL_DIR="${SCRIPT_DIR}/khiops-python-tutorial"
 
 # Function to display the usage help
 usage() {
-  echo "Usage: create-doc [-r REPO_URL] [-d] [-t] [-l]"
+  echo "Usage: create-doc [-r REPO_URL] [-d] [-t] [-g] [-l]"
   echo "Options:"
   echo "  -d: Downloads the Khiops tutorial repository. Implies -t. See also -r."
   echo "  -t: Transform the Khiops Jupyter notebooks tutorials into reST."
-  echo "  -r: Set the Khiops tutorial repository. The default is"
+  echo "  -r: Set the Khiops tutorial repository URL. The default is"
   echo "      '$DEFAULT_KHIOPS_TUTORIAL_REPO_URL'."
+  echo "  -g: Set the Khiops tutorial repository Git reference. The default is"
+  echo "      '$DEFAULT_KHIOPS_TUTORIAL_REPO_REF'."
   echo "  -l: Directory of the local copy of the khiops tutorial repository. The default is"
   echo "      '$DEFAULT_KHIOPS_TUTORIAL_DIR'."
   echo ""
@@ -29,17 +32,19 @@ exit_bad() {
 }
 
 # Read command line arguments
-while getopts "dtr:l:" opt
+while getopts "dtrg:l:" opt
 do
   case "$opt" in
     d ) DOWNLOAD_REPO=true && TRANSFORM_NOTEBOOKS="true" ;;
     t ) TRANSFORM_NOTEBOOKS="true" ;;
     r ) KHIOPS_TUTORIAL_REPO_URL="$OPTARG" ;;
+    g ) KHIOPS_TUTORIAL_REPO_REF="$OPTARG" ;;
     l ) KHIOPS_TUTORIAL_REPO_DIR="$OPTARG" ;;
     * ) exit_bad ;;
   esac
 done
 KHIOPS_TUTORIAL_REPO_URL="${KHIOPS_TUTORIAL_REPO_URL:-$DEFAULT_KHIOPS_TUTORIAL_REPO_URL}"
+KHIOPS_TUTORIAL_REPO_REF="${KHIOPS_TUTORIAL_REPO_REF:-$DEFAULT_KHIOPS_TUTORIAL_REPO_REF}"
 KHIOPS_TUTORIAL_REPO_DIR="${KHIOPS_TUTORIAL_REPO_DIR:-$DEFAULT_KHIOPS_TUTORIAL_DIR}"
 
 
@@ -69,10 +74,9 @@ done
 # Clone the Khiops tutorial repository
 if [[ $DOWNLOAD_REPO ]]
 then
-  echo "Obtaining khiops-python-tutorial"
+  echo "Obtaining khiops-python-tutorial revision $KHIOPS_TUTORIAL_REPO_REF"
   rm -rf "$KHIOPS_TUTORIAL_REPO_DIR"
-  khiops_python_tutorial_repo_branch="main"
-  git clone --depth 1 --branch="$khiops_python_tutorial_repo_branch" \
+  git clone --depth 1 --branch="$KHIOPS_TUTORIAL_REPO_REF" \
       "$KHIOPS_TUTORIAL_REPO_URL" "$KHIOPS_TUTORIAL_REPO_DIR" \
       && rm -rf "$KHIOPS_TUTORIAL_REPO_DIR/.git"
 fi


### PR DESCRIPTION
closes #415 

---

### TODO Before Asking for a Review
- [x] Rebase your branch to the latest version of `dev` (or `main` for release PRs)
- [x] Make sure all CI workflows are green
- [ ] When adding a public feature/fix: Update the `Unreleased` section of `CHANGELOG.md` (no date)
- [x] Self-Review: Review "Files Changed" tab and fix any problems you find
- API Docs (only if there are changes in docstrings, rst files or samples):
  - [x] Check the docs build **without** warning: see the log of the API Docs workflow
  - [x] Check that your changes render well in HTML: download the API Docs artifact and open `index.html`
  - If there are any problems it is faster to iterate by [building locally the API Docs](../blob/dev/doc/README.md#build-the-documentation)
