### PR TITLE
Expose the sklearn.helpers package in the API docs (porting from v10 to v11)

### DIFF
--- a/doc/sklearn/index.rst
+++ b/doc/sklearn/index.rst
@@ -15,6 +15,7 @@ khiops.sklearn
   :nosignatures:
 
   estimators
+  helpers
 
 Related Docs
 ------------


### PR DESCRIPTION
Expose the sklearn.helpers package in the API docs

---

### TODO Before Asking for a Review
- [ X] Rebase your branch to the latest version of `dev` (or `main` for release PRs)
- [ X] Make sure all CI workflows are green
- [ ] When adding a public feature/fix: Update the `Unreleased` section of `CHANGELOG.md` (no date)
- [ X] Self-Review: Review "Files Changed" tab and fix any problems you find
- API Docs (only if there are changes in docstrings, rst files or samples):
  - [ X] Check the docs build **without** warning: see the log of the API Docs workflow
  - [ X] Check that your changes render well in HTML: download the API Docs artifact and open `index.html`
  - If there are any problems it is faster to iterate by [building locally the API Docs](../blob/dev/doc/README.md#build-the-documentation)
