### PR TITLE
Release 10.3.2.0

### DIFF
--- a/.github/workflows/api-docs.yml
+++ b/.github/workflows/api-docs.yml
@@ -41,7 +41,7 @@ jobs:
       # because the `env` context is only accessible at the step level;
       # hence, it is hard-coded
       image: |-
-        ghcr.io/khiopsml/khiops-python/khiopspydev-ubuntu22.04:${{ inputs.image-tag || '10.3.2.0' }}
+        ghcr.io/khiopsml/khiops-python/khiopspydev-ubuntu22.04:${{ inputs.image-tag || 'latest' }}
       # Use the 'runner' user (1001) from github so checkout actions work properly
       # https://github.com/actions/runner/issues/2033#issuecomment-1598547465
       options: --user 1001

--- a/.github/workflows/api-docs.yml
+++ b/.github/workflows/api-docs.yml
@@ -5,11 +5,6 @@ env:
 on:
   workflow_dispatch:
     inputs:
-      deploy-gh-pages:
-        description: Deploy GH Pages
-        required: true
-        type: boolean
-        default: false
       khiops-python-tutorial-revision:
         default: 10.3.1.0
         description: khiops-python-tutorial repo revision
@@ -24,6 +19,8 @@ on:
       - doc/*.py
       - khiops/**.py
       - .github/workflows/api-docs.yml
+  push:
+    tags: ['*']
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
   contents: read
@@ -49,20 +46,10 @@ jobs:
       # https://github.com/actions/runner/issues/2033#issuecomment-1598547465
       options: --user 1001
     steps:
-      - name: Set parameters as env
-        run: |
-          KHIOPS_PYTHON_TUTORIAL_REVISION=${{ inputs.khiops-python-tutorial-revision || env.DEFAULT_KHIOPS_PYTHON_TUTORIAL_REVISION }}
-          echo "KHIOPS_PYTHON_TUTORIAL_REVISION=$KHIOPS_PYTHON_TUTORIAL_REVISION" >> "$GITHUB_ENV"
       - name: Checkout khiops-python
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Checkout khiops-python-tutorial
-        uses: actions/checkout@v4
-        with:
-          repository: khiopsml/khiops-python-tutorial
-          ref: ${{ env.KHIOPS_PYTHON_TUTORIAL_REVISION }}
-          path: doc/khiops-python-tutorial
       - name: Add pip scripts directory to path
         run: echo PATH="$PATH:/github/home/.local/bin" >> "$GITHUB_ENV"
       - name: Install doc build requirements
@@ -75,25 +62,43 @@ jobs:
           # Install the doc python requirements
           cd doc
           pip3 install -U -r requirements.txt
+      # Clone the Khiops Python tutorial repository while building the documentation
       - name: Build Sphinx Documentation
         run: |
           cd doc
-          ./create-doc -t
+          ./create-doc -t -d -g \
+          ${{ inputs.khiops-python-tutorial-revision || env.DEFAULT_KHIOPS_PYTHON_TUTORIAL_REVISION }}
       - name: Upload the docs as an artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          path: doc/_build/html/
-  # Deploy only when the user explicitly (and manually) orders it
-  deploy:
-    if: github.event_name == 'workflow_dispatch' && inputs.deploy-gh-pages == true
-    runs-on: ubuntu-latest
+          name: api-docs
+          path: ./doc/_build/html/
+  # Release on Git tag
+  release:
+    if: github.ref_type == 'tag'
     needs: build
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: write
     steps:
-      - name: Setup Pages
-        uses: actions/configure-pages@v4
-      - name: Deploy API Docs to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+      - name: Download docs artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: api-docs
+          path: ./doc/_build/html/
+      - name: Create docs release zip archive
+        uses: thedoctor0/zip-release@0.7.6
+        with:
+          type: zip
+          path: ./doc/_build/html/
+          filename: khiops-api-docs-${{ github.ref_name }}.zip
+      - name: Release the docs zip archive
+        uses: ncipollo/release-action@v1.15.0
+        with:
+          allowUpdates: true
+          artifacts: ./khiops-api-docs-${{ github.ref_name }}.zip
+          body: '**For testing purposes only**'
+          draft: false
+          makeLatest: false
+          prerelease: true
+          updateOnlyUnreleased: true

--- a/.github/workflows/api-docs.yml
+++ b/.github/workflows/api-docs.yml
@@ -41,7 +41,7 @@ jobs:
       # because the `env` context is only accessible at the step level;
       # hence, it is hard-coded
       image: |-
-        ghcr.io/khiopsml/khiops-python/khiopspydev-ubuntu22.04:${{ inputs.image-tag || 'latest' }}
+        ghcr.io/khiopsml/khiops-python/khiopspydev-ubuntu22.04:${{ inputs.image-tag || '10.3.2.0' }}
       # Use the 'runner' user (1001) from github so checkout actions work properly
       # https://github.com/actions/runner/issues/2033#issuecomment-1598547465
       options: --user 1001

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -3,16 +3,16 @@ name: Conda Package
 env:
   # Note: The default Khiops version must never be an alpha release as they are
   #       ephemeral. To test alpha versions run the workflow manually.
-  DEFAULT_KHIOPS_CORE_VERSION: 10.3.1
-  DEFAULT_SAMPLES_VERSION: 10.2.4
+  DEFAULT_KHIOPS_CORE_VERSION: 10.3.2
+  DEFAULT_SAMPLES_VERSION: 10.3.2
 on:
   workflow_dispatch:
     inputs:
       khiops-core-version:
-        default: 10.3.1
+        default: 10.3.2
         description: khiops-core version for testing
       khiops-samples-version:
-        default: 10.2.4
+        default: 10.3.2
         description: khiops-samples version
       release-channel:
         type: choice
@@ -57,10 +57,8 @@ jobs:
       - name: Install Dependency Requirements for Building Conda Packages
         run: conda install -y conda-build
       - name: Build the Conda Package
-        # Note: The "khiops-dev" conda channel is needed to retrieve the "khiops-core" package.
-        #       The "test" part of the conda recipe needs this package.
         run: |
-          conda build --channel khiops-dev --output-folder ./khiops-conda ./packaging/conda
+          conda build --output-folder ./khiops-conda ./packaging/conda
       - name: Upload Conda Package Artifact
         uses: actions/upload-artifact@v4
         with:
@@ -80,8 +78,8 @@ jobs:
           - {os: ubuntu-24.04, json-image: '{"image": null}'}
           - {os: ubuntu-22.04, json-image: '{"image": "rockylinux:8"}'}
           - {os: ubuntu-22.04, json-image: '{"image": "rockylinux:9"}'}
-          - {os: windows-2019, json-image: '{"image": null}'}
           - {os: windows-2022, json-image: '{"image": null}'}
+          - {os: windows-2025, json-image: '{"image": null}'}
           - {os: macos-13, json-image: '{"image": null}'}
           - {os: macos-14, json-image: '{"image": null}'}
           - {os: macos-15, json-image: '{"image": null}'}
@@ -105,7 +103,7 @@ jobs:
           echo "KHIOPS_CORE_VERSION=$KHIOPS_CORE_VERSION" >> "$GITHUB_ENV"
       - name: Install the Khiops Conda package
         run: |
-          conda install --channel khiops-dev khiops-core=$KHIOPS_CORE_VERSION
+          conda install khiops-core=$KHIOPS_CORE_VERSION
           conda install --channel ./khiops-conda/ khiops
       - name: Test Khiops Installation Status
         run: kh-status

--- a/.github/workflows/dev-docker.yml
+++ b/.github/workflows/dev-docker.yml
@@ -1,7 +1,7 @@
 ---
 name: Dev Docker
 env:
-  DEFAULT_KHIOPS_REVISION: 10.3.1
+  DEFAULT_KHIOPS_REVISION: 10.3.2
   DEFAULT_IMAGE_INCREMENT: 0
   DEFAULT_SERVER_REVISION: main
   DEFAULT_PYTHON_VERSIONS: 3.8 3.9 3.10 3.11 3.12 3.13
@@ -14,7 +14,7 @@ on:
     inputs:
       khiops-revision:
         type: string
-        default: 10.3.1
+        default: 10.3.2
         description: Khiops Revision
       image-increment:
         type: number

--- a/.github/workflows/pip.yml
+++ b/.github/workflows/pip.yml
@@ -1,12 +1,12 @@
 ---
 name: Pip Package
 env:
-  DEFAULT_SAMPLES_REVISION: 10.2.4
+  DEFAULT_SAMPLES_REVISION: 10.3.2
 on:
   workflow_dispatch:
     inputs:
       samples-revision:
-        default: 10.2.4
+        default: 10.3.2
         description: khiops-samples repo revision
       image-tag:
         default: latest
@@ -64,7 +64,7 @@ jobs:
       # because the `env` context is only accessible at the step level;
       # hence, it is hard-coded
       image: |-
-        ghcr.io/khiopsml/khiops-python/khiopspydev-${{ matrix.container }}:${{ inputs.image-tag || 'latest' }}
+        ghcr.io/khiopsml/khiops-python/khiopspydev-${{ matrix.container }}:${{ inputs.image-tag || '10.3.2.0' }}
     steps:
       - name: Set parameters as env
         run: |
@@ -106,9 +106,10 @@ jobs:
           kh-samples core -i train_coclustering -e
           kh-samples sklearn -i khiops_classifier -e
 
-          # Test that the line containing "MPI command" also contains
-          # an executable named "mpiexec"
-          kh-status | grep "MPI command" | grep -wq "mpiexec"
+          # Test that the line containing "MPI command" does not contain "<empty>"
+          # The MPI command is not always named mpiexec, but can be orterun etc
+          # (as given by khiops_env)
+          kh-status | grep "MPI command" | grep -vwq "<empty>"
   release:
     if: github.ref_type == 'tag'
     needs: [build, test]

--- a/.github/workflows/pip.yml
+++ b/.github/workflows/pip.yml
@@ -64,7 +64,7 @@ jobs:
       # because the `env` context is only accessible at the step level;
       # hence, it is hard-coded
       image: |-
-        ghcr.io/khiopsml/khiops-python/khiopspydev-${{ matrix.container }}:${{ inputs.image-tag || '10.3.2.0' }}
+        ghcr.io/khiopsml/khiops-python/khiopspydev-${{ matrix.container }}:${{ inputs.image-tag || 'latest' }}
     steps:
       - name: Set parameters as env
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,7 +43,7 @@ jobs:
       # because the `env` context is only accessible at the step level;
       # hence, it is hard-coded
       image: |-
-        ghcr.io/khiopsml/khiops-python/khiopspydev-ubuntu22.04:${{ inputs.image-tag || '10.3.2.0' }}
+        ghcr.io/khiopsml/khiops-python/khiopspydev-ubuntu22.04:${{ inputs.image-tag || 'latest' }}
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -312,7 +312,7 @@ jobs:
       # because the `env` context is only accessible at the step level;
       # hence, it is hard-coded
       image: |-
-        ghcr.io/khiopsml/khiops-python/khiopspydev-${{ matrix.container }}:${{ inputs.image-tag || '10.3.2.0' }}
+        ghcr.io/khiopsml/khiops-python/khiopspydev-${{ matrix.container }}:${{ inputs.image-tag || 'latest' }}
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,19 +1,19 @@
 ---
 name: Tests
 env:
-  DEFAULT_SAMPLES_REVISION: 10.2.4
-  DEFAULT_KHIOPS_DESKTOP_REVISION: 10.3.1
+  DEFAULT_SAMPLES_REVISION: 10.3.2
+  DEFAULT_KHIOPS_DESKTOP_REVISION: 10.3.2
 on:
   workflow_dispatch:
     inputs:
       samples-revision:
-        default: 10.2.4
+        default: 10.3.2
         description: Git Tag/Branch/Commit for the khiops-samples Repo
       image-tag:
         default: latest
         description: Development Docker Image Tag
       khiops-desktop-revision:
-        default: 10.3.1
+        default: 10.3.2
         description: Khiops Windows Desktop Application Version
       run-expensive-tests:
         type: boolean
@@ -43,7 +43,7 @@ jobs:
       # because the `env` context is only accessible at the step level;
       # hence, it is hard-coded
       image: |-
-        ghcr.io/khiopsml/khiops-python/khiopspydev-ubuntu22.04:${{ inputs.image-tag || 'latest' }}
+        ghcr.io/khiopsml/khiops-python/khiopspydev-ubuntu22.04:${{ inputs.image-tag || '10.3.2.0' }}
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -211,7 +211,7 @@ jobs:
             tests/resources/general_options/general_options/*/*._kh
           retention-days: 7
   check-khiops-integration-on-windows:
-    runs-on: windows-2019
+    runs-on: windows-2022
     steps:
       - name: Download the Khiops Desktop NSIS Installer
         shell: pwsh
@@ -312,7 +312,7 @@ jobs:
       # because the `env` context is only accessible at the step level;
       # hence, it is hard-coded
       image: |-
-        ghcr.io/khiopsml/khiops-python/khiopspydev-${{ matrix.container }}:${{ inputs.image-tag || 'latest' }}
+        ghcr.io/khiopsml/khiops-python/khiopspydev-${{ matrix.container }}:${{ inputs.image-tag || '10.3.2.0' }}
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@
   - Example: 10.2.1.4 is the 5th version that supports khiops 10.2.1.
 - Internals: Changes in *Internals* sections are unlikely to be of interest for data scientists.
 
+## 10.3.2.0 - 2025-07-03
+
+### Fixed
+- (`sklearn`) Documentation display for the `train_test_split_dataset` sklearn
+helper function.
+
 ## 10.3.1.0 - 2025-04-16
 
 ### Added

--- a/doc/create-doc
+++ b/doc/create-doc
@@ -7,17 +7,20 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 # Default parameter values
 TRANSFORM_NOTEBOOKS=""
 DOWNLOAD_REPO=""
-DEFAULT_KHIOPS_TUTORIAL_REPO_URL="git@github.com:KhiopsML/khiops-python-tutorial.git"
+DEFAULT_KHIOPS_TUTORIAL_REPO_URL="https://github.com/KhiopsML/khiops-python-tutorial.git"
+DEFAULT_KHIOPS_TUTORIAL_REPO_REF="main"
 DEFAULT_KHIOPS_TUTORIAL_DIR="${SCRIPT_DIR}/khiops-python-tutorial"
 
 # Function to display the usage help
 usage() {
-  echo "Usage: create-doc [-r REPO_URL] [-d] [-t] [-l]"
+  echo "Usage: create-doc [-r REPO_URL] [-d] [-t] [-g] [-l]"
   echo "Options:"
   echo "  -d: Downloads the Khiops tutorial repository. Implies -t. See also -r."
   echo "  -t: Transform the Khiops Jupyter notebooks tutorials into reST."
-  echo "  -r: Set the Khiops tutorial repository. The default is"
+  echo "  -r: Set the Khiops tutorial repository URL. The default is"
   echo "      '$DEFAULT_KHIOPS_TUTORIAL_REPO_URL'."
+  echo "  -g: Set the Khiops tutorial repository Git reference. The default is"
+  echo "      '$DEFAULT_KHIOPS_TUTORIAL_REPO_REF'."
   echo "  -l: Directory of the local copy of the khiops tutorial repository. The default is"
   echo "      '$DEFAULT_KHIOPS_TUTORIAL_DIR'."
   echo ""
@@ -29,17 +32,19 @@ exit_bad() {
 }
 
 # Read command line arguments
-while getopts "dtr:l:" opt
+while getopts "dtrg:l:" opt
 do
   case "$opt" in
     d ) DOWNLOAD_REPO=true && TRANSFORM_NOTEBOOKS="true" ;;
     t ) TRANSFORM_NOTEBOOKS="true" ;;
     r ) KHIOPS_TUTORIAL_REPO_URL="$OPTARG" ;;
+    g ) KHIOPS_TUTORIAL_REPO_REF="$OPTARG" ;;
     l ) KHIOPS_TUTORIAL_REPO_DIR="$OPTARG" ;;
     * ) exit_bad ;;
   esac
 done
 KHIOPS_TUTORIAL_REPO_URL="${KHIOPS_TUTORIAL_REPO_URL:-$DEFAULT_KHIOPS_TUTORIAL_REPO_URL}"
+KHIOPS_TUTORIAL_REPO_REF="${KHIOPS_TUTORIAL_REPO_REF:-$DEFAULT_KHIOPS_TUTORIAL_REPO_REF}"
 KHIOPS_TUTORIAL_REPO_DIR="${KHIOPS_TUTORIAL_REPO_DIR:-$DEFAULT_KHIOPS_TUTORIAL_DIR}"
 
 
@@ -69,10 +74,9 @@ done
 # Clone the Khiops tutorial repository
 if [[ $DOWNLOAD_REPO ]]
 then
-  echo "Obtaining khiops-python-tutorial"
+  echo "Obtaining khiops-python-tutorial revision $KHIOPS_TUTORIAL_REPO_REF"
   rm -rf "$KHIOPS_TUTORIAL_REPO_DIR"
-  khiops_python_tutorial_repo_branch="main"
-  git clone --depth 1 --branch="$khiops_python_tutorial_repo_branch" \
+  git clone --depth 1 --branch="$KHIOPS_TUTORIAL_REPO_REF" \
       "$KHIOPS_TUTORIAL_REPO_URL" "$KHIOPS_TUTORIAL_REPO_DIR" \
       && rm -rf "$KHIOPS_TUTORIAL_REPO_DIR/.git"
 fi

--- a/doc/sklearn/index.rst
+++ b/doc/sklearn/index.rst
@@ -15,6 +15,7 @@ khiops.sklearn
   :nosignatures:
 
   estimators
+  helpers
 
 Related Docs
 ------------

--- a/packaging/conda/meta.yaml
+++ b/packaging/conda/meta.yaml
@@ -26,7 +26,7 @@ requirements:
     - python
   run:
     - python
-    - khiops-core >=10.3.1,<10.3.2
+    - khiops-core >=10.3.2,<10.3.3
     - pandas >=0.25.3
     - scikit-learn >=0.22.2
   run_constrained:

--- a/packaging/docker/khiopspydev/Dockerfile.rocky
+++ b/packaging/docker/khiopspydev/Dockerfile.rocky
@@ -78,7 +78,7 @@ RUN true \
         do \
             $CONDA create -y -n $CONDA_ENV python=${version}; \
         done; \
-        $CONDA install -y -n py${version}_conda -c khiops-dev khiops-core=$(echo ${KHIOPS_REVISION} | tr -d "-") ; \
+        $CONDA install -y -n py${version}_conda khiops-core=$(echo ${KHIOPS_REVISION} | tr -d "-") ; \
     done' \
   && true
 

--- a/packaging/docker/khiopspydev/Dockerfile.ubuntu
+++ b/packaging/docker/khiopspydev/Dockerfile.ubuntu
@@ -52,7 +52,7 @@ RUN true \
             $CONDA create -y -n $CONDA_ENV python=${version}; \
         done; \
         # khiops core \
-        $CONDA install -y -n py${version}_conda -c khiops-dev khiops-core=$(echo ${KHIOPS_REVISION} | tr -d "-") ; \
+        $CONDA install -y -n py${version}_conda khiops-core=$(echo ${KHIOPS_REVISION} | tr -d "-") ; \
         # remote files drivers installed in the conda environment \
         $CONDA install -y -n py${version}_conda -c khiops \
         khiops-driver-s3=${KHIOPS_S3_DRIVER_REVISION} \


### PR DESCRIPTION
Full-extent CI-based checks (including extensive tests) have been performed on the `dev-v10` HEAD (viz. the **10.3.2.0-rc.1** tag).