### PR TITLE
Update to khiops core on conda forge backport from v10

### DIFF
--- a/.github/workflows/api-docs.yml
+++ b/.github/workflows/api-docs.yml
@@ -9,7 +9,7 @@ on:
         default: main
         description: khiops-python-tutorial repo revision
       image-tag:
-        default: 10.7.3-a.0.0
+        default: 11.0.0-a.0.0
         description: Development Docker Image Tag
   pull_request:
     paths:
@@ -41,7 +41,7 @@ jobs:
       # because the `env` context is only accessible at the step level;
       # hence, it is hard-coded
       image: |-
-        ghcr.io/khiopsml/khiops-python/khiopspydev-ubuntu22.04:${{ inputs.image-tag || '10.7.3-a.0.0' }}
+        ghcr.io/khiopsml/khiops-python/khiopspydev-ubuntu22.04:${{ inputs.image-tag || '11.0.0-a.0.0' }}
       # Use the 'runner' user (1001) from github so checkout actions work properly
       # https://github.com/actions/runner/issues/2033#issuecomment-1598547465
       options: --user 1001

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -103,7 +103,13 @@ jobs:
           echo "KHIOPS_CORE_VERSION=$KHIOPS_CORE_VERSION" >> "$GITHUB_ENV"
       - name: Install the Khiops Conda package
         run: |
-          conda install khiops-core=$KHIOPS_CORE_VERSION
+          # Add the Conda `rc` label for alpha or RC pre-releases
+          if [[ $(echo ${KHIOPS_CORE_VERSION} | grep -E ".*(a|rc)\.[0-9]+") ]]; then
+            RC_LABEL="conda-forge/label/rc::"
+          else
+            RC_LABEL=""
+          fi
+          conda install ${RC_LABEL}khiops-core=$KHIOPS_CORE_VERSION
           conda install --channel ./khiops-conda/ khiops
       - name: Test Khiops Installation Status
         run: kh-status

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -57,10 +57,8 @@ jobs:
       - name: Install Dependency Requirements for Building Conda Packages
         run: conda install -y conda-build
       - name: Build the Conda Package
-        # Note: The "khiops-dev" conda channel is needed to retrieve the "khiops-core" package.
-        #       The "test" part of the conda recipe needs this package.
         run: |
-          conda build --channel khiops-dev --output-folder ./khiops-conda ./packaging/conda
+          conda build --output-folder ./khiops-conda ./packaging/conda
       - name: Upload Conda Package Artifact
         uses: actions/upload-artifact@v4
         with:
@@ -105,7 +103,7 @@ jobs:
           echo "KHIOPS_CORE_VERSION=$KHIOPS_CORE_VERSION" >> "$GITHUB_ENV"
       - name: Install the Khiops Conda package
         run: |
-          conda install --channel khiops-dev khiops-core=$KHIOPS_CORE_VERSION
+          conda install khiops-core=$KHIOPS_CORE_VERSION
           conda install --channel ./khiops-conda/ khiops
       - name: Test Khiops Installation Status
         run: kh-status

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -78,8 +78,8 @@ jobs:
           - {os: ubuntu-24.04, json-image: '{"image": null}'}
           - {os: ubuntu-22.04, json-image: '{"image": "rockylinux:8"}'}
           - {os: ubuntu-22.04, json-image: '{"image": "rockylinux:9"}'}
-          - {os: windows-2019, json-image: '{"image": null}'}
           - {os: windows-2022, json-image: '{"image": null}'}
+          - {os: windows-2025, json-image: '{"image": null}'}
           - {os: macos-13, json-image: '{"image": null}'}
           - {os: macos-14, json-image: '{"image": null}'}
           - {os: macos-15, json-image: '{"image": null}'}

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -3,13 +3,13 @@ name: Conda Package
 env:
   # Note: The default Khiops version must never be an alpha release as they are
   #       ephemeral. To test alpha versions run the workflow manually.
-  DEFAULT_KHIOPS_CORE_VERSION: 10.7.3a.0
+  DEFAULT_KHIOPS_CORE_VERSION: 11.0.0a.0
   DEFAULT_SAMPLES_VERSION: 11.0.0
 on:
   workflow_dispatch:
     inputs:
       khiops-core-version:
-        default: 10.7.3a.0
+        default: 11.0.0a.0
         description: khiops-core version for testing
       khiops-samples-version:
         default: 11.0.0

--- a/.github/workflows/dev-docker.yml
+++ b/.github/workflows/dev-docker.yml
@@ -1,7 +1,7 @@
 ---
 name: Dev Docker
 env:
-  DEFAULT_KHIOPS_REVISION: 10.7.3-a.0
+  DEFAULT_KHIOPS_REVISION: 11.0.0-a.0
   DEFAULT_IMAGE_INCREMENT: 0
   DEFAULT_SERVER_REVISION: main
   DEFAULT_PYTHON_VERSIONS: 3.8 3.9 3.10 3.11 3.12 3.13
@@ -14,7 +14,7 @@ on:
     inputs:
       khiops-revision:
         type: string
-        default: 10.7.3-a.0
+        default: 11.0.0-a.0
         description: Khiops Revision
       image-increment:
         type: number

--- a/.github/workflows/pip.yml
+++ b/.github/workflows/pip.yml
@@ -106,9 +106,11 @@ jobs:
           kh-samples core -i train_coclustering -e
           kh-samples sklearn -i khiops_classifier -e
 
-          # Test that the line containing "MPI command" also contains
-          # an executable named "mpiexec"
-          kh-status | grep "MPI command" | grep -wq "mpiexec"
+          # Test that the line containing "MPI command" does not contain "<empty>"
+          # (as given by kh-status in the absence of MPI support)
+          # The MPI command is not always named mpiexec, but can be orterun etc
+          # (as given by khiops_env)
+          kh-status | grep "MPI command" | grep -vwq "<empty>"
   release:
     if: github.ref_type == 'tag'
     needs: [build, test]

--- a/.github/workflows/pip.yml
+++ b/.github/workflows/pip.yml
@@ -9,7 +9,7 @@ on:
         default: 11.0.0
         description: khiops-samples repo revision
       image-tag:
-        default: 10.7.3-a.0.0
+        default: 11.0.0-a.0.0
         description: Development Docker Image Tag
   pull_request:
     paths:
@@ -64,7 +64,7 @@ jobs:
       # because the `env` context is only accessible at the step level;
       # hence, it is hard-coded
       image: |-
-        ghcr.io/khiopsml/khiops-python/khiopspydev-${{ matrix.container }}:${{ inputs.image-tag || '10.7.3-a.0.0' }}
+        ghcr.io/khiopsml/khiops-python/khiopspydev-${{ matrix.container }}:${{ inputs.image-tag || '11.0.0-a.0.0' }}
     steps:
       - name: Set parameters as env
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ on:
         default: 11.0.0
         description: Git Tag/Branch/Commit for the khiops-samples Repo
       image-tag:
-        default: 10.7.3-a.0.0
+        default: 11.0.0-a.0.0
         description: Development Docker Image Tag
       khiops-desktop-revision:
         default: 11.0.0-a.0
@@ -43,7 +43,7 @@ jobs:
       # because the `env` context is only accessible at the step level;
       # hence, it is hard-coded
       image: |-
-        ghcr.io/khiopsml/khiops-python/khiopspydev-ubuntu22.04:${{ inputs.image-tag || '10.7.3-a.0.0' }}
+        ghcr.io/khiopsml/khiops-python/khiopspydev-ubuntu22.04:${{ inputs.image-tag || '11.0.0-a.0.0' }}
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -315,7 +315,7 @@ jobs:
       # because the `env` context is only accessible at the step level;
       # hence, it is hard-coded
       image: |-
-        ghcr.io/khiopsml/khiops-python/khiopspydev-${{ matrix.container }}:${{ inputs.image-tag || '10.7.3-a.0.0' }}
+        ghcr.io/khiopsml/khiops-python/khiopspydev-${{ matrix.container }}:${{ inputs.image-tag || '11.0.0-a.0.0' }}
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -214,7 +214,7 @@ jobs:
             tests/resources/general_options/general_options/*/*._kh
           retention-days: 7
   check-khiops-integration-on-windows:
-    runs-on: windows-2019
+    runs-on: windows-2022
     steps:
       - name: Download the Khiops Desktop NSIS Installer
         shell: pwsh

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,7 +2,7 @@
 name: Tests
 env:
   DEFAULT_SAMPLES_REVISION: 11.0.0
-  DEFAULT_KHIOPS_DESKTOP_REVISION: 10.7.3-a.0
+  DEFAULT_KHIOPS_DESKTOP_REVISION: 11.0.0-a.0
 on:
   workflow_dispatch:
     inputs:
@@ -13,7 +13,7 @@ on:
         default: 10.7.3-a.0.0
         description: Development Docker Image Tag
       khiops-desktop-revision:
-        default: 10.7.3-a.0
+        default: 11.0.0-a.0
         description: Khiops Windows Desktop Application Version
       run-expensive-tests:
         type: boolean

--- a/packaging/conda/meta.yaml
+++ b/packaging/conda/meta.yaml
@@ -26,7 +26,7 @@ requirements:
     - python
   run:
     - python
-    - khiops-core =10.7.3a.0
+    - khiops-core =11.0.0a.0
     - pandas >=0.25.3
     - scikit-learn >=0.22.2
   run_constrained:

--- a/packaging/conda/meta.yaml
+++ b/packaging/conda/meta.yaml
@@ -26,7 +26,7 @@ requirements:
     - python
   run:
     - python
-    - khiops-core =11.0.0a.0
+    - conda-forge/label/rc::khiops-core =11.0.0a.0
     - pandas >=0.25.3
     - scikit-learn >=0.22.2
   run_constrained:

--- a/packaging/docker/khiopspydev/Dockerfile.rocky
+++ b/packaging/docker/khiopspydev/Dockerfile.rocky
@@ -78,7 +78,7 @@ RUN true \
         do \
             $CONDA create -y -n $CONDA_ENV python=${version}; \
         done; \
-        $CONDA install -y -n py${version}_conda -c khiops-dev khiops-core=$(echo ${KHIOPS_REVISION} | tr -d "-") ; \
+        $CONDA install -y -n py${version}_conda khiops-core=$(echo ${KHIOPS_REVISION} | tr -d "-") ; \
     done' \
   && true
 

--- a/packaging/docker/khiopspydev/Dockerfile.rocky
+++ b/packaging/docker/khiopspydev/Dockerfile.rocky
@@ -69,8 +69,16 @@ RUN true \
 # set up all the supported Python environments under conda (for the unit tests)
 # relying on a variable containing all the versions
 ARG PYTHON_VERSIONS
+
+# Install Conda packages
+# Use `rc` label for alpha or RC khiops-core pre-releases
 RUN true \
   && export CONDA="/root/miniforge3/bin/conda" \
+  && if [[ $(echo ${KHIOPS_REVISION} | grep -E ".*-(a|rc)\.[0-9]+") ]]; then \
+       export RC_LABEL="conda-forge/label/rc::"; \
+     else \
+       export RC_LABEL=""; \
+     fi \
   && /bin/bash -c 'for version in ${PYTHON_VERSIONS}; \
     do \
         CONDA_ENVS="py${version} py${version}_conda"; \
@@ -78,7 +86,7 @@ RUN true \
         do \
             $CONDA create -y -n $CONDA_ENV python=${version}; \
         done; \
-        $CONDA install -y -n py${version}_conda khiops-core=$(echo ${KHIOPS_REVISION} | tr -d "-") ; \
+        $CONDA install -y -n py${version}_conda ${RC_LABEL}khiops-core=$(echo ${KHIOPS_REVISION} | tr -d "-") ; \
     done' \
   && true
 

--- a/packaging/docker/khiopspydev/Dockerfile.ubuntu
+++ b/packaging/docker/khiopspydev/Dockerfile.ubuntu
@@ -52,7 +52,7 @@ RUN true \
             $CONDA create -y -n $CONDA_ENV python=${version}; \
         done; \
         # khiops core \
-        $CONDA install -y -n py${version}_conda -c khiops-dev khiops-core=$(echo ${KHIOPS_REVISION} | tr -d "-") ; \
+        $CONDA install -y -n py${version}_conda khiops-core=$(echo ${KHIOPS_REVISION} | tr -d "-") ; \
         # remote files drivers installed in the conda environment \
         $CONDA install -y -n py${version}_conda -c khiops \
         khiops-driver-s3=${KHIOPS_S3_DRIVER_REVISION} \

--- a/packaging/docker/khiopspydev/Dockerfile.ubuntu
+++ b/packaging/docker/khiopspydev/Dockerfile.ubuntu
@@ -42,8 +42,16 @@ RUN true \
 ARG PYTHON_VERSIONS
 ARG KHIOPS_GCS_DRIVER_REVISION
 ARG KHIOPS_S3_DRIVER_REVISION
+
+# Install Conda packages
+# Use `rc` label for alpha or RC khiops-core pre-releases
 RUN true \
   && export CONDA="/root/miniforge3/bin/conda" \
+  && if [[ $(echo ${KHIOPS_REVISION} | grep -E ".*-(a|rc)\.[0-9]+") ]]; then \
+       export RC_LABEL="conda-forge/label/rc::"; \
+     else \
+       export RC_LABEL=""; \
+     fi \
   && /bin/bash -c 'for version in ${PYTHON_VERSIONS}; \
     do \
         CONDA_ENVS="py${version} py${version}_conda"; \
@@ -52,7 +60,7 @@ RUN true \
             $CONDA create -y -n $CONDA_ENV python=${version}; \
         done; \
         # khiops core \
-        $CONDA install -y -n py${version}_conda khiops-core=$(echo ${KHIOPS_REVISION} | tr -d "-") ; \
+        $CONDA install -y -n py${version}_conda ${RC_LABEL}khiops-core=$(echo ${KHIOPS_REVISION} | tr -d "-") ; \
         # remote files drivers installed in the conda environment \
         $CONDA install -y -n py${version}_conda -c khiops \
         khiops-driver-s3=${KHIOPS_S3_DRIVER_REVISION} \


### PR DESCRIPTION
Tie some loose ends related to:
- the khiops-core Conda package being published on conda-forge
- the maintenance of the CI (phase-out of the windows-2019 runner)

---

### TODO Before Asking for a Review
- [x] Rebase your branch to the latest version of `dev` (or `main` for release PRs)
- [x] Make sure all CI workflows are green
- [ ] When adding a public feature/fix: Update the `Unreleased` section of `CHANGELOG.md` (no date)
- [x] Self-Review: Review "Files Changed" tab and fix any problems you find
- API Docs (only if there are changes in docstrings, rst files or samples):
  - [ ] Check the docs build **without** warning: see the log of the API Docs workflow
  - [ ] Check that your changes render well in HTML: download the API Docs artifact and open `index.html`
  - If there are any problems it is faster to iterate by [building locally the API Docs](../blob/dev/doc/README.md#build-the-documentation)
