### PR TITLE
Backport : fix the khiops version initialization independently of the OS

### DIFF
--- a/khiops/core/internals/runner.py
+++ b/khiops/core/internals/runner.py
@@ -952,8 +952,10 @@ class KhiopsLocalRunner(KhiopsRunner):
 
         # On success parse and save the version
         if return_code == 0:
-            # Skip potential non-version lines (ex: Completed loading of file driver...)
-            for line in stdout.split(os.linesep):
+            # Skip potential non-version lines
+            # (ex: Completed loading of file driver, debug info ...)
+            for line in stdout.split("\n"):
+                line = line.strip("\r")  # remove Windows-specific Carriage-Return
                 if line.startswith("Khiops"):
                     khiops_version_str = line.rstrip().split(" ")[1]
                     break


### PR DESCRIPTION
It should always work despite noise (drivers logs, debug info)

---

### TODO Before Asking for a Review
- [x] Rebase your branch to the latest version of `dev` (or `main` for release PRs)
- [x] Make sure all CI workflows are green
- [ ] When adding a public feature/fix: Update the `Unreleased` section of `CHANGELOG.md` (no date)
- [x] Self-Review: Review "Files Changed" tab and fix any problems you find
- API Docs (only if there are changes in docstrings, rst files or samples):
  - [x] Check the docs build **without** warning: see the log of the API Docs workflow
  - [ ] Check that your changes render well in HTML: download the API Docs artifact and open `index.html`
  - If there are any problems it is faster to iterate by [building locally the API Docs](../blob/dev/doc/README.md#build-the-documentation)
