### PR TITLE
Fix KhiopsVersion import in samples tests

### DIFF
--- a/tests/test_samples.py
+++ b/tests/test_samples.py
@@ -8,6 +8,7 @@
 import unittest
 
 import khiops.core as kh
+from khiops.core.internals.version import KhiopsVersion
 from khiops.samples import samples, samples_sklearn
 from tests.test_helper import KhiopsTestHelper
 
@@ -22,8 +23,8 @@ class KhiopsSamplesTests(unittest.TestCase):
         """Test if all samples run without problems"""
         # Obtain the runner version and set the minimal requirements for some samples
         min_version = {
-            samples.detect_data_table_format: kh.KhiopsVersion("10.0.1"),
-            samples.deploy_coclustering: kh.KhiopsVersion("10.0.1"),
+            samples.detect_data_table_format: KhiopsVersion("10.0.1"),
+            samples.deploy_coclustering: KhiopsVersion("10.0.1"),
         }
 
         # Run the samples


### PR DESCRIPTION
Fix KhiopsVersion import in samples tests.

This is required after PR https://github.com/KhiopsML/khiops-python/pull/437.

---

### TODO Before Asking for a Review
- [ ] Rebase your branch to the latest version of `dev` (or `main` for release PRs)
- [ ] Make sure all CI workflows are green
- [ ] When adding a public feature/fix: Update the `Unreleased` section of `CHANGELOG.md` (no date)
- [ ] Self-Review: Review "Files Changed" tab and fix any problems you find
- API Docs (only if there are changes in docstrings, rst files or samples):
  - [ ] Check the docs build **without** warning: see the log of the API Docs workflow
  - [ ] Check that your changes render well in HTML: download the API Docs artifact and open `index.html`
  - If there are any problems it is faster to iterate by [building locally the API Docs](../blob/dev/doc/README.md#build-the-documentation)
