### PR TITLE
Only allow setting `.rule` to a string representation of a rule

### DIFF
--- a/khiops/core/dictionary.py
+++ b/khiops/core/dictionary.py
@@ -1187,7 +1187,7 @@ class Variable:
         self.structure_type = ""
 
         # Derivation rule
-        self.rule = ""
+        self._rule = ""
 
         # Metadata
         self.meta_data = MetaData()
@@ -1223,7 +1223,7 @@ class Variable:
             self.structure_type = json_data.get("structureType")
 
         # Initialize derivation rule
-        self.rule = json_data.get("rule", "")
+        self._rule = json_data.get("rule", "")
 
         # Initialize metadata
         json_meta_data = json_data.get("metaData")
@@ -1248,6 +1248,16 @@ class Variable:
     def name(self, value):
         _check_name(value)
         self._name = value
+
+    @property
+    def rule(self):
+        return self._rule
+
+    @rule.setter
+    def rule(self, value):
+        if not is_string_like(value):
+            raise TypeError(type_error_message("rule", value, "string-like"))
+        self._rule = value
 
     def copy(self):
         """Copies this variable instance
@@ -1479,7 +1489,7 @@ class VariableBlock:
         self.internal_comments = json_data.get("internalComments", [])
 
         # Initialize derivation rule
-        self.rule = json_data.get("rule", "")
+        self._rule = json_data.get("rule", "")
 
         # Initialize metadata if available
         json_meta_data = json_data.get("metaData")
@@ -1503,6 +1513,16 @@ class VariableBlock:
         writer = KhiopsOutputWriter(stream)
         self.write(writer)
         return str(stream.getvalue(), encoding="utf8", errors="replace")
+
+    @property
+    def rule(self):
+        return self._rule
+
+    @rule.setter
+    def rule(self, value):
+        if not is_string_like(value):
+            raise TypeError(type_error_message("rule", value, "string-like"))
+        self._rule = value
 
     def add_variable(self, variable):
         """Adds a variable to this block

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1916,6 +1916,9 @@ class KhiopsCoreServicesTests(unittest.TestCase):
                     repr(dictionary.get_variable("fresh_one").get_rule()),
                     "Variable rule must be set correctly",
                 )
+                variable_rule = kh.Rule(verbatim="Ceil(Product(3, Random()))")
+                with self.assertRaises(TypeError):
+                    dictionary.get_variable("fresh_one").rule = variable_rule
 
                 # Test Dictionary variable block accessors
                 # Create a simple block
@@ -1959,7 +1962,9 @@ class KhiopsCoreServicesTests(unittest.TestCase):
 
                 # Set the block as non-native add, and remove it
                 dictionary_copy.add_variable_block(block)
-                block_rule = kh.Rule("SomeBlockCreatingRule()")
+                block_rule = kh.Rule("SomeBlockCreatingRule")
+                with self.assertRaises(TypeError):
+                    dictionary_copy.get_variable_block(block.name).rule = block_rule
                 dictionary_copy.get_variable_block(block.name).set_rule(block_rule)
                 self.assertEqual(block, dictionary_copy.get_variable_block(block.name))
                 removed_block = dictionary_copy.remove_variable_block(


### PR DESCRIPTION
Make `.rule = ` only accept string representation of rules. Thus, backward compatibility is ensured and the `khiops.core.dictionary.Rule` objects remain reserved to the `Variable.set_rule / Variable.get_rule` method combo.

---

### TODO Before Asking for a Review
- [ ] Rebase your branch to the latest version of `dev` (or `main` for release PRs)
- [ ] Make sure all CI workflows are green
- [ ] When adding a public feature/fix: Update the `Unreleased` section of `CHANGELOG.md` (no date)
- [ ] Self-Review: Review "Files Changed" tab and fix any problems you find
- API Docs (only if there are changes in docstrings, rst files or samples):
  - [ ] Check the docs build **without** warning: see the log of the API Docs workflow
  - [ ] Check that your changes render well in HTML: download the API Docs artifact and open `index.html`
  - If there are any problems it is faster to iterate by [building locally the API Docs](../blob/dev/doc/README.md#build-the-documentation)
