### PR TITLE
Improve the warning in case of versions mismatch between the khiops binaries and the khiops python library

### DIFF
--- a/khiops/core/internals/runner.py
+++ b/khiops/core/internals/runner.py
@@ -1072,13 +1072,17 @@ class KhiopsLocalRunner(KhiopsRunner):
             compatible_khiops_version.minor,
             compatible_khiops_version.patch,
         ):
+            operating_system = platform.system()
+            installation_method = _infer_khiops_installation_method()
             warnings.warn(
-                f"Khiops version '{self._khiops_version}' does not match "
-                f"the Khiops Python library version '{khiops.__version__}' "
-                "(different major.minor.patch version). "
+                f"Version '{self._khiops_version}' of the Khiops executables "
+                "does not match the Khiops Python library version "
+                f"'{khiops.__version__}' (different major.minor.patch version). "
                 "There may be compatibility errors and "
-                "we recommend to update either Khiops binaries or "
-                "the Khiops Python library. "
+                "we recommend to update either the Khiops "
+                f"executables package for your '{operating_system}' operating "
+                "system, or the Khiops Python library, "
+                f"according to your '{installation_method}' environment. "
                 "See https://khiops.org for more information.",
                 stacklevel=3,
             )


### PR DESCRIPTION
- rephrase "binaries" to "executables"
- add the OS and the environment to the message


Fixes #476 

---

### TODO Before Asking for a Review
- [x] Rebase your branch to the latest version of `dev` (or `main` for release PRs)
- [x] Make sure all CI workflows are green
- [ ] When adding a public feature/fix: Update the `Unreleased` section of `CHANGELOG.md` (no date)
- [x] Self-Review: Review "Files Changed" tab and fix any problems you find
- API Docs (only if there are changes in docstrings, rst files or samples):
  - [x] Check the docs build **without** warning: see the log of the API Docs workflow
  - [x] Check that your changes render well in HTML: download the API Docs artifact and open `index.html`
  - If there are any problems it is faster to iterate by [building locally the API Docs](../blob/dev/doc/README.md#build-the-documentation)
