### PR TITLE
Set-up remote credentials only if expensive tests are not skipped

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -117,6 +117,7 @@ jobs:
         if: github.ref != 'dev' && github.ref != 'dev-v10' && github.ref != 'main' && ! inputs.run-expensive-tests
         run: echo "SKIP_EXPENSIVE_TESTS=true" >> "$GITHUB_ENV"
       - name: Prepare Integration Tests on remote files
+        if: env.SKIP_EXPENSIVE_TESTS != 'true'
         env:
           AWS_ENDPOINT_URL: http://localhost:4569
         shell: bash
@@ -139,6 +140,7 @@ jobs:
           cat  ${GITHUB_WORKSPACE}/.aws/configuration
           /scripts/run_fake_remote_file_servers.sh .  # launch the servers in the background
       - name: Authenticate to GCP using "Workload Identity Federation"
+        if: env.SKIP_EXPENSIVE_TESTS != 'true'
         # For integration tests on GCS we use a real Google account
         # Retrieve the Google credentials through "Workload Identity Federation"
         # see https://github.com/google-github-actions/auth?tab=readme-ov-file#workload-identity-federation-through-a-service-account


### PR DESCRIPTION
Thus, PRs done from forks can have their Test workflow run after approval (without the expensive tests which are supposed to be run from `dev` after merge anyway).

### TODO Before Asking for a Review
- [ ] Rebase your branch to the latest version of `dev` (or `main` for release PRs)
- [ ] Make sure all CI workflows are green
- [ ] When adding a public feature/fix: Update the `Unreleased` section of `CHANGELOG.md` (no date)
- [ ] Self-Review: Review "Files Changed" tab and fix any problems you find
- API Docs (only if there are changes in docstrings, rst files or samples):
  - [ ] Check the docs build **without** warning: see the log of the API Docs workflow
  - [ ] Check that your changes render well in HTML: download the API Docs artifact and open `index.html`
  - If there are any problems it is faster to iterate by [building locally the API Docs](../blob/dev/doc/README.md#build-the-documentation)
