### PR TITLE
Add coclustering report edge cases for ill-formed 'intervals'

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1584,6 +1584,31 @@ class KhiopsCoreServicesTests(unittest.TestCase):
             dimension.init_summary(json_data="NOT A DICT")
         with self.assertRaises(TypeError):
             dimension.init_partition(json_data="NOT A DICT")
+        dimension.init_summary(json_data={"name": "PartName", "type": "Numerical"})
+        with self.assertRaises(kh.KhiopsJSONError) as cm:
+            dimension.init_partition(
+                json_data={
+                    "name": dimension.name,
+                    "type": dimension.type,
+                    "intervals": [],
+                }
+            )
+        self.assertIn(
+            "'intervals' key must have length at least 1", cm.exception.args[0]
+        )
+        with self.assertRaises(kh.KhiopsJSONError) as cm:
+            dimension.init_partition(
+                json_data={
+                    "name": dimension.name,
+                    "type": dimension.type,
+                    "intervals": [None],
+                }
+            )
+        self.assertIn(
+            "'intervals' key must have at least 2 elements when one element "
+            "contains missing values",
+            cm.exception.args[0],
+        )
         with self.assertRaises(TypeError):
             dimension.init_hierarchy(json_data="NOT A DICT")
         with self.assertRaises(TypeError):


### PR DESCRIPTION
- test for no interval
- test for single-interval which contains missing values

---

### TODO Before Asking for a Review
- [x] Rebase your branch to the latest version of `dev` (or `main` for release PRs)
- [ ] Make sure all CI workflows are green
- [ ] When adding a public feature/fix: Update the `Unreleased` section of `CHANGELOG.md` (no date)
- [x] Self-Review: Review "Files Changed" tab and fix any problems you find
- API Docs (only if there are changes in docstrings, rst files or samples):
  - [ ] Check the docs build **without** warning: see the log of the API Docs workflow
  - [ ] Check that your changes render well in HTML: download the API Docs artifact and open `index.html`
  - If there are any problems it is faster to iterate by [building locally the API Docs](../blob/dev/doc/README.md#build-the-documentation)
