### PR TITLE
Change the behavior of all the getters in the public API when the responding key is not found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@
 - (`core`) New way to add a variable to a dictionary using a complete specification.
 - (`sklearn`) `Text` Khiops type support at the estimator level.
 
+### Changed
+- (`core`) Dictionary API and analysis and coclustering reports, 
+  when a requested key is not found in getters, return a ``None`` value instead
+  of raising a `KeyError` exception.
+
 ### Fixed
 - (General) Inconsistency between the `tools.download_datasets` function and the
   current samples directory according to `core.api.get_samples_dir()`.

--- a/khiops/core/analysis_results.py
+++ b/khiops/core/analysis_results.py
@@ -575,14 +575,10 @@ class PreparationReport:
         Returns
         -------
         `VariableStatistics`
-            The statistics of the specified variable.
-
-        Raises
-        ------
-        `KeyError`
-            If no variable with the specified names exist.
+            The statistics of the specified variable. A ``None`` value is returned
+            if the variable name is not found.
         """
-        return self._variables_statistics_by_name[variable_name]
+        return self._variables_statistics_by_name.get(variable_name)
 
     def get_tree(self, tree_name):
         """Returns the tree with the specified name
@@ -595,14 +591,10 @@ class PreparationReport:
         Returns
         -------
         `Tree`
-            The tree which has the specified name.
-
-        Raises
-        ------
-        `KeyError`
-            If no tree with the specified name exists.
+            The tree which has the specified name. A ``None`` value is returned
+            if the tree name is not found.
         """
-        return self._trees_by_name[tree_name]
+        return self._trees_by_name.get(tree_name)
 
     def to_dict(self):
         """Transforms this instance to a dict with the Khiops JSON file structure"""
@@ -1045,15 +1037,12 @@ class BivariatePreparationReport:
         -------
         `VariablePairStatistics`
             The statistics of the specified pair of variables.
-
-        Raises
-        ------
-        `KeyError`
-            If no pair with the specified names exist.
+             A ``None`` value is returned if no pair with the
+             specified names exist.
         """
-        return self._variables_pairs_statistics_by_name[
+        return self._variables_pairs_statistics_by_name.get(
             (variable_name_1, variable_name_2)
-        ]
+        )
 
     def to_dict(self):
         """Transforms this instance to a dict with the Khiops JSON file structure"""
@@ -1306,14 +1295,10 @@ class ModelingReport:
         Returns
         -------
         `TrainedPredictor`
-            The predictor object for the specified name.
-
-        Raises
-        ------
-        `KeyError`
-            If there is no predictor with the specified name.
+            The predictor object for the specified name. A ``None`` value is
+            returned if the predictor name is not found.
         """
-        return self._trained_predictors_by_name[predictor_name]
+        return self._trained_predictors_by_name.get(predictor_name)
 
     def get_snb_predictor(self):
         """Returns the Selective Naive Bayes predictor
@@ -1321,12 +1306,8 @@ class ModelingReport:
         Returns
         -------
         `TrainedPredictor`
-            The predictor object for "Selective Naive Bayes".
-
-        Raises
-        ------
-        `KeyError`
-            If there is no predictor named "Selective Naive Bayes".
+            The predictor object for "Selective Naive Bayes". A ``None`` value is
+            returned if there is no predictor named "Selective Naive Bayes".
         """
         return self.get_predictor("Selective Naive Bayes")
 
@@ -1588,14 +1569,10 @@ class EvaluationReport:
         Returns
         -------
         `PredictorPerformance`
-            The performance metrics for the specified predictor.
-
-        Raises
-        ------
-        `KeyError`
-            If no predictor with the specified name exists.
+            The performance metrics for the specified predictor. A ``None`` value
+            is returned if the predictor name is not found.
         """
-        return self._predictors_performance_by_name[predictor_name]
+        return self._predictors_performance_by_name.get(predictor_name)
 
     def get_snb_performance(self):
         """Returns the performance metrics for the Selective Naive Bayes predictor
@@ -1625,21 +1602,20 @@ class EvaluationReport:
         Returns
         -------
         `PredictorCurve`
-            The REC curve for the specified regressor.
+            The REC curve for the specified regressor. A ``None`` value is
+            returned if the regressor name is not found.
 
         Raises
         ------
         `ValueError`
-            If no regressor curves available. (
-        `KeyError`
-            If no regressor with the specified name exists.
+            If no regressor curves available.
         """
         if self.learning_task != "Regression analysis":
             raise ValueError("REC curves are available only for regression")
         for curve in self.regression_rec_curves:
             if curve.name == regressor_name:
                 return curve
-        raise KeyError(regressor_name)
+        return None
 
     def get_snb_rec_curve(self):
         """Returns the REC curve for the Selective Naive Bayes regressor
@@ -1675,12 +1651,8 @@ class EvaluationReport:
         -------
         `PredictorCurve`
             The lift curve for the specified classifier and target value.
-
-        Raises
-        ------
-        `KeyError`
-            If no classifier with the specified exists or no target value with the
-            specified name exists.
+            A ``None`` value is returned if no classifier with the specified
+            exists or no target value with the specified name exists.
         """
         if self.learning_task != "Classification analysis":
             raise ValueError("Lift curves are available only for classification")
@@ -1701,8 +1673,7 @@ class EvaluationReport:
                     for lift_curve in self.classification_lift_curves[i]:
                         if lift_curve.name == classifier_name:
                             return lift_curve
-                    raise KeyError(classifier_name)
-        raise KeyError(target_value)
+        return None
 
     def get_snb_lift_curve(self, target_value):
         """Returns lift curve for the Selective Naive Bayes clf. given a target value
@@ -1716,14 +1687,8 @@ class EvaluationReport:
         -------
         `PredictorCurve`
             The lift curve of the Selective Naive Bayes classifier for the specified
-            target value.
-
-        Raises
-        ------
-        `ValueError`
-            If the Selective Naive Bayes classifier information is not available.
-        `KeyError`
-            If no target value with the specified name exists.
+            target value. A ``None`` value is returned if no Selective Naive Bayes
+            classifier information is available.
         """
         if self.learning_task != "Classification analysis":
             raise ValueError("Lift curves are available only for classification")
@@ -1732,10 +1697,7 @@ class EvaluationReport:
                 for lift_curve in self.classification_lift_curves[i]:
                     if lift_curve.name == "Selective Naive Bayes":
                         return lift_curve
-                raise ValueError(
-                    "Selective Naive Bayes classifier information not available"
-                )
-        raise KeyError(target_value)
+        return None
 
     def to_dict(self):
         """Transforms this instance to a dict with the Khiops JSON file structure"""

--- a/khiops/core/coclustering_results.py
+++ b/khiops/core/coclustering_results.py
@@ -479,14 +479,10 @@ class CoclusteringReport:
         Returns
         -------
         `CoclusteringDimension`
-            The specified dimension.
-
-        Raises
-        ------
-        `KeyError`
-            If no dimension with the specified names exist.
+            The specified dimension. A ``None`` value is returned
+            if the dimension name is not found.
         """
-        return self._dimensions_by_name[dimension_name]
+        return self._dimensions_by_name.get(dimension_name)
 
     def to_dict(self):
         """Transforms this instance to a dict with the Khiops JSON file structure"""
@@ -1062,14 +1058,10 @@ class CoclusteringDimension:
         Returns
         -------
         `CoclusteringDimensionPart`
-            The part with the specified name.
-
-        Raises
-        ------
-        `KeyError`
-            If there is no part with the specified name.
+            The part with the specified name. A ``None`` value is returned
+            if the part name is not found.
         """
-        return self._parts_by_name[part_name]
+        return self._parts_by_name.get(part_name)
 
     def get_cluster(self, cluster_name):
         """Returns the specified cluster
@@ -1082,14 +1074,10 @@ class CoclusteringDimension:
         Returns
         -------
         `CoclusteringCluster`
-            The specified cluster.
-
-        Raises
-        ------
-        `KeyError`
-            If there is no cluster with the specified name.
+            The specified cluster. A ``None`` value is returned
+            if the cluster name is not found.
         """
-        return self._clusters_by_name[cluster_name]
+        return self._clusters_by_name.get(cluster_name)
 
     def to_dict(self, report_type):
         """Transforms this instance to a dict with the Khiops JSON file structure

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1409,8 +1409,9 @@ class KhiopsCoreServicesTests(unittest.TestCase):
             )
 
         # Test anomalous access
-        with self.assertRaises(KeyError):
-            report.get_variable_statistics("INEXISTENT VARIABLE NAME")
+        self.assertEqual(
+            None, report.get_variable_statistics("INEXISTENT VARIABLE NAME")
+        )
 
     def _test_bivariate_preparation_report_accessors(
         self, result_file_name, report, expected_outputs
@@ -1433,8 +1434,10 @@ class KhiopsCoreServicesTests(unittest.TestCase):
             )
 
         # Test anomalous access
-        with self.assertRaises(KeyError):
-            report.get_variable_pair_statistics("INEXISTENT VARIABLE", "PAIR NAME")
+        self.assertEqual(
+            None,
+            report.get_variable_pair_statistics("INEXISTENT VARIABLE", "PAIR NAME"),
+        )
 
     def _test_modeling_report_accessors(
         self, result_file_name, report, expected_outputs
@@ -1455,8 +1458,7 @@ class KhiopsCoreServicesTests(unittest.TestCase):
         )
 
         # Test anomalous access
-        with self.assertRaises(KeyError):
-            report.get_predictor("INEXISTENT REPORT NAME")
+        self.assertIsNone(report.get_predictor("INEXISTENT REPORT NAME"))
 
     def _test_evaluation_report_accessors(
         self, result_file_name, report, expected_outputs
@@ -1481,8 +1483,9 @@ class KhiopsCoreServicesTests(unittest.TestCase):
         )
 
         # Test anomalous access
-        with self.assertRaises(KeyError):
-            report.get_predictor_performance("INEXISTENT REPORT NAME")
+        self.assertEqual(
+            None, report.get_predictor_performance("INEXISTENT REPORT NAME")
+        )
 
         # Test anomalous access to performance objects
         for predictor_name in report.get_predictor_names():
@@ -1510,15 +1513,24 @@ class KhiopsCoreServicesTests(unittest.TestCase):
                 else:
                     report.get_classifier_lift_curve(predictor_name, "INEXISTENT VALUE")
             if report.learning_task == "Classification analysis":
-                with self.assertRaises(KeyError):
-                    report.get_classifier_lift_curve(predictor_name, "INEXISTENT VALUE")
-        with self.assertRaises(KeyError):
-            if report.learning_task == "Classification analysis":
+                self.assertEqual(
+                    None,
+                    report.get_classifier_lift_curve(
+                        predictor_name, "INEXISTENT VALUE"
+                    ),
+                )
+
+        if report.learning_task == "Classification analysis":
+            self.assertEqual(
+                None,
                 report.get_classifier_lift_curve(
                     "INEXISTENT PREDICTOR", report.classification_target_values[0]
-                )
-            else:
-                report.get_regressor_rec_curve("INEXISTENT PREDICTOR")
+                ),
+            )
+        else:
+            self.assertEqual(
+                None, report.get_regressor_rec_curve("INEXISTENT PREDICTOR")
+            )
 
         # Test anomalous access to SNB curves
         with self.assertRaises(ValueError):
@@ -1527,8 +1539,7 @@ class KhiopsCoreServicesTests(unittest.TestCase):
             else:
                 report.get_snb_lift_curve("INEXISTENT VALUE")
         if report.learning_task == "Classification analysis":
-            with self.assertRaises(KeyError):
-                report.get_snb_lift_curve("INEXISTENT VALUE")
+            self.assertIsNone(report.get_snb_lift_curve("INEXISTENT VALUE"))
 
     def _test_performance_report_accessors(
         self, result_file_name, learning_task, report, expected_outputs
@@ -1796,8 +1807,7 @@ class KhiopsCoreServicesTests(unittest.TestCase):
         with self.assertRaises(TypeError):
             meta_data.remove_key(object())
         meta_data.add_value("key", "value")
-        with self.assertRaises(KeyError):
-            meta_data.get_value("INEXISTENT KEY")
+        self.assertIsNone(meta_data.get_value("INEXISTENT KEY"))
         with self.assertRaises(ValueError):
             meta_data.add_value("key", "REPEATED KEY")
         with self.assertRaises(KeyError):
@@ -1967,8 +1977,8 @@ class KhiopsCoreServicesTests(unittest.TestCase):
                 self.assertEqual(block, removed_block)
                 self.assertIsNone(block_variable.variable_block)
                 self.assertEqual(block.variables, [])
-                with self.assertRaises(KeyError):
-                    dictionary_copy.get_variable_block(block.name)
+                # Nonexistent variable block name
+                self.assertIsNone(dictionary_copy.get_variable_block(block.name))
 
                 # Add and remove the block and remove the native variables
                 dictionary_copy.remove_variable(block_variable.name)
@@ -1981,10 +1991,12 @@ class KhiopsCoreServicesTests(unittest.TestCase):
                 self.assertEqual(block, removed_block)
                 self.assertEqual(block.variables, [block_variable])
                 self.assertEqual(block_variable.block, removed_block)
-                with self.assertRaises(KeyError):
-                    dictionary_copy.get_variable(block_variable.name)
-                with self.assertRaises(KeyError):
-                    dictionary_copy.get_variable_block(block.name)
+                # Nonexistent variable block name
+                self.assertEqual(
+                    None, dictionary_copy.get_variable(block_variable.name)
+                )
+                # Nonexistent variable name
+                self.assertIsNone(dictionary_copy.get_variable_block(block.name))
 
                 # Set the block as non-native add, and remove it
                 dictionary_copy.add_variable_block(block)
@@ -1999,10 +2011,12 @@ class KhiopsCoreServicesTests(unittest.TestCase):
                 self.assertEqual(block, removed_block)
                 self.assertEqual(block.variables, [block_variable])
                 self.assertEqual(block_variable.block, removed_block)
-                with self.assertRaises(KeyError):
-                    dictionary_copy.get_variable(block_variable.name)
-                with self.assertRaises(KeyError):
-                    dictionary_copy.get_variable_block(block.name)
+                # Nonexistent variable block name
+                self.assertEqual(
+                    None, dictionary_copy.get_variable(block_variable.name)
+                )
+                # Nonexistent variable name
+                self.assertIsNone(dictionary_copy.get_variable_block(block.name))
 
                 # Test Dictionary variable and block accessors by cleaning the dict.
                 for variable_name in [


### PR DESCRIPTION
Instead of raising a `KeyError`, a ``None`` value is returned (like the dict behavior)


Fixes #405 

The change was quite mechanical but a complete verification must be done to find cases where a `ValueError` instead of a `KeyError` and should also be replaced by a ``None`` return value (cf comment https://github.com/KhiopsML/khiops-python/issues/405#issuecomment-3361853973) 


---

### TODO Before Asking for a Review
- [x] Rebase your branch to the latest version of `dev` (or `main` for release PRs)
- [x] Make sure all CI workflows are green
- [x] When adding a public feature/fix: Update the `Unreleased` section of `CHANGELOG.md` (no date)
- [x] Self-Review: Review "Files Changed" tab and fix any problems you find
- API Docs (only if there are changes in docstrings, rst files or samples):
  - [ ] Check the docs build **without** warning: see the log of the API Docs workflow
  - [ ] Check that your changes render well in HTML: download the API Docs artifact and open `index.html`
  - If there are any problems it is faster to iterate by [building locally the API Docs](../blob/dev/doc/README.md#build-the-documentation)
