### PR TITLE
Change the behavior of all the getters in the Dictionary API when the corresponding key is not found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@
 - (`core`) New way to add a variable to a dictionary using a complete specification.
 - (`sklearn`) `Text` Khiops type support at the estimator level.
 
+### Changed
+- (`core`) Dictionary API (DictionaryDomain, Dictionary, MetaData), 
+  when a requested key is not found in getters, return ``None`` instead
+  of raising a `KeyError` exception.
+
 ### Fixed
 - (General) Inconsistency between the `tools.download_datasets` function and the
   current samples directory according to `core.api.get_samples_dir()`.

--- a/khiops/core/dictionary.py
+++ b/khiops/core/dictionary.py
@@ -238,15 +238,10 @@ class DictionaryDomain(KhiopsJSONObject):
         Returns
         -------
         `Dictionary`
-            The specified dictionary.
-
-        Raises
-        ------
-        `KeyError`
-            If no dictionary with the specified name exist.
-
+            The specified dictionary. ``None`` is returned if the dictionary name
+            is not found.
         """
-        return self._dictionaries_by_name[dictionary_name]
+        return self._dictionaries_by_name.get(dictionary_name)
 
     def add_dictionary(self, dictionary):
         """Adds a dictionary to this domain
@@ -409,20 +404,16 @@ class DictionaryDomain(KhiopsJSONObject):
         data_path_parts = data_path.split("`")
         source_dictionary_name = data_path_parts[0]
 
-        try:
-            dictionary = self.get_dictionary(source_dictionary_name)
-        except KeyError as error:
-            raise ValueError(
-                f"Source dictionary not found: '{source_dictionary_name}'"
-            ) from error
+        dictionary = self.get_dictionary(source_dictionary_name)
+        if dictionary is None:
+            raise ValueError(f"Source dictionary not found: '{source_dictionary_name}'")
 
         for table_variable_name in data_path_parts[1:]:
-            try:
-                table_variable = dictionary.get_variable(table_variable_name)
-            except KeyError as error:
+            table_variable = dictionary.get_variable(table_variable_name)
+            if table_variable is None:
                 raise ValueError(
                     f"Table variable '{table_variable_name}' in data path not found"
-                ) from error
+                )
 
             if table_variable.type not in ["Table", "Entity"]:
                 raise ValueError(
@@ -430,13 +421,12 @@ class DictionaryDomain(KhiopsJSONObject):
                     f"in data path is of type '{table_variable.type}'"
                 )
 
-            try:
-                dictionary = self.get_dictionary(table_variable.object_type)
-            except KeyError as error:
+            dictionary = self.get_dictionary(table_variable.object_type)
+            if dictionary is None:
                 raise ValueError(
                     f"Table variable '{table_variable_name}' in data path "
                     f"points to unknown dictionary '{table_variable.object_type}'"
-                ) from error
+                )
         return dictionary
 
     def _get_dictionary_at_data_path(self, data_path):
@@ -447,32 +437,34 @@ class DictionaryDomain(KhiopsJSONObject):
         # - either it is found as such,
         # - or it is a Table or Entity variable whose table needs to be looked-up
         first_table_variable_name = data_path_parts[0]
-        try:
-            dictionary = self.get_dictionary(first_table_variable_name)
-        except KeyError as error:
+
+        dictionary = self.get_dictionary(first_table_variable_name)
+        if dictionary is None:
             for a_dictionary in self.dictionaries:
                 try:
                     table_variable = a_dictionary.get_variable(
                         first_table_variable_name
                     )
-                    if table_variable.type not in ["Table", "Entity"]:
-                        raise ValueError from error
-                    dictionary = self.get_dictionary(table_variable.object_type)
-                    break
-                except (KeyError, ValueError):
+                    if table_variable is not None:
+                        if table_variable.type not in ["Table", "Entity"]:
+                            raise ValueError(
+                                f"Variable '{table_variable}' "
+                                "must be of type 'Table' or 'Entity'"
+                            )
+                        dictionary = self.get_dictionary(table_variable.object_type)
+                        if dictionary is not None:
+                            break
+                except ValueError:
                     continue
             else:
-                raise ValueError(
-                    f"Dictionary not found in data path: '{data_path}'"
-                ) from error
+                raise ValueError(f"Dictionary not found in data path: '{data_path}'")
 
         for table_variable_name in data_path_parts[1:]:
-            try:
-                table_variable = dictionary.get_variable(table_variable_name)
-            except KeyError as error:
+            table_variable = dictionary.get_variable(table_variable_name)
+            if table_variable is None:
                 raise ValueError(
                     f"Table variable '{table_variable_name}' in data path not found"
-                ) from error
+                )
 
             if table_variable.type not in ["Table", "Entity"]:
                 raise ValueError(
@@ -480,13 +472,12 @@ class DictionaryDomain(KhiopsJSONObject):
                     f"in data path is of type '{table_variable.type}'"
                 )
 
-            try:
-                dictionary = self.get_dictionary(table_variable.object_type)
-            except KeyError as error:
+            dictionary = self.get_dictionary(table_variable.object_type)
+            if dictionary is None:
                 raise ValueError(
                     f"Table variable '{table_variable_name}' in data path "
                     f"points to unknown dictionary '{table_variable.object_type}'"
-                ) from error
+                )
         return dictionary
 
     def export_khiops_dictionary_file(self, kdic_file_path):
@@ -740,10 +731,11 @@ class Dictionary:
     def get_value(self, key):
         """Returns the metadata value associated to the specified key
 
-        Raises
-        ------
-        `KeyError`
-            If the key is not found
+        Returns
+        -------
+        `Metadata`
+            Metadata value associated to the specified key. ``None`` is returned
+            if the metadata key is not found.
         """
         return self.meta_data.get_value(key)
 
@@ -770,14 +762,10 @@ class Dictionary:
         Returns
         -------
         `Variable`
-            The specified variable.
-
-        Raises
-        ------
-        `KeyError`
-            If no variable with the specified name exists.
+            The specified variable. ``None`` is returned if the variable name is
+            not found.
         """
-        return self._variables_by_name[variable_name]
+        return self._variables_by_name.get(variable_name)
 
     def get_variable_block(self, variable_block_name):
         """Returns the specified variable block
@@ -790,15 +778,10 @@ class Dictionary:
         Returns
         -------
         `VariableBlock`
-            The specified variable.
-
-        Raises
-        ------
-        `KeyError`
-            If no variable block with the specified name exists.
-
+            The specified variable block. ``None`` is returned if the variable
+            block name is not found.
         """
-        return self._variable_blocks_by_name[variable_block_name]
+        return self._variable_blocks_by_name.get(variable_block_name)
 
     def add_variable(self, variable):
         """Adds a variable to this dictionary
@@ -1282,10 +1265,11 @@ class Variable:
     def get_value(self, key):
         """Returns the metadata value associated to the specified key
 
-        Raises
-        ------
-        `KeyError`
-            If no metadata has this key.
+        Returns
+        -------
+        `Metadata`
+            Metadata value associated to the specified key. ``None`` is returned
+            if the metadata key is not found.
         """
         return self.meta_data.get_value(key)
 
@@ -1541,10 +1525,11 @@ class VariableBlock:
     def get_value(self, key):
         """Returns the metadata value associated to the specified key
 
-        Raises
-        ------
-        `KeyError`
-            If ``key`` is not found
+        Returns
+        -------
+        `Metadata`
+            Metadata value associated to the specified key. ``None`` is returned
+            if the metadata key is not found.
         """
         return self.meta_data.get_value(key)
 
@@ -2019,14 +2004,13 @@ class MetaData:
         Returns
         -------
         int, str or float
-            The value at the specified key
+            The value at the specified key. ``None`` is returned if the key is
+            not found.
 
         Raises
         ------
         `TypeError`
             If ``key`` is not str.
-        `KeyError`
-            If ``key`` is not found.
         """
         # Check the argument types
         if not is_string_like(key):
@@ -2036,7 +2020,7 @@ class MetaData:
         for i, stored_key in enumerate(self.keys):
             if stored_key == key:
                 return self.values[i]
-        raise KeyError(key)
+        return None
 
     def add_value(self, key, value):
         """Adds a value at the specified key

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1796,8 +1796,7 @@ class KhiopsCoreServicesTests(unittest.TestCase):
         with self.assertRaises(TypeError):
             meta_data.remove_key(object())
         meta_data.add_value("key", "value")
-        with self.assertRaises(KeyError):
-            meta_data.get_value("INEXISTENT KEY")
+        self.assertIsNone(meta_data.get_value("INEXISTENT KEY"))
         with self.assertRaises(ValueError):
             meta_data.add_value("key", "REPEATED KEY")
         with self.assertRaises(KeyError):
@@ -1967,8 +1966,8 @@ class KhiopsCoreServicesTests(unittest.TestCase):
                 self.assertEqual(block, removed_block)
                 self.assertIsNone(block_variable.variable_block)
                 self.assertEqual(block.variables, [])
-                with self.assertRaises(KeyError):
-                    dictionary_copy.get_variable_block(block.name)
+                # Nonexistent variable block name
+                self.assertIsNone(dictionary_copy.get_variable_block(block.name))
 
                 # Add and remove the block and remove the native variables
                 dictionary_copy.remove_variable(block_variable.name)
@@ -1981,10 +1980,10 @@ class KhiopsCoreServicesTests(unittest.TestCase):
                 self.assertEqual(block, removed_block)
                 self.assertEqual(block.variables, [block_variable])
                 self.assertEqual(block_variable.block, removed_block)
-                with self.assertRaises(KeyError):
-                    dictionary_copy.get_variable(block_variable.name)
-                with self.assertRaises(KeyError):
-                    dictionary_copy.get_variable_block(block.name)
+                # Nonexistent variable block name
+                self.assertIsNone(dictionary_copy.get_variable(block_variable.name))
+                # Nonexistent variable name
+                self.assertIsNone(dictionary_copy.get_variable_block(block.name))
 
                 # Set the block as non-native add, and remove it
                 dictionary_copy.add_variable_block(block)
@@ -1999,10 +1998,10 @@ class KhiopsCoreServicesTests(unittest.TestCase):
                 self.assertEqual(block, removed_block)
                 self.assertEqual(block.variables, [block_variable])
                 self.assertEqual(block_variable.block, removed_block)
-                with self.assertRaises(KeyError):
-                    dictionary_copy.get_variable(block_variable.name)
-                with self.assertRaises(KeyError):
-                    dictionary_copy.get_variable_block(block.name)
+                # Nonexistent variable block name
+                self.assertIsNone(dictionary_copy.get_variable(block_variable.name))
+                # Nonexistent variable name
+                self.assertIsNone(dictionary_copy.get_variable_block(block.name))
 
                 # Test Dictionary variable and block accessors by cleaning the dict.
                 for variable_name in [


### PR DESCRIPTION

- The impacted classes are `DictionaryDomain`, `Dictionary` and `MetaData`
- Instead of raising a KeyError, a ``None`` value is returned (like the dict behavior)


Fixes #405

---

### TODO Before Asking for a Review
- [x] Rebase your branch to the latest version of `dev` (or `main` for release PRs)
- [x] Make sure all CI workflows are green
- [x] When adding a public feature/fix: Update the `Unreleased` section of `CHANGELOG.md` (no date)
- [x] Self-Review: Review "Files Changed" tab and fix any problems you find
- API Docs (only if there are changes in docstrings, rst files or samples):
  - [x] Check the docs build **without** warning: see the log of the API Docs workflow
  - [ ] Check that your changes render well in HTML: download the API Docs artifact and open `index.html`
  - If there are any problems it is faster to iterate by [building locally the API Docs](../blob/dev/doc/README.md#build-the-documentation)
