### PR TITLE
Fix a border case for local fs copy from local

### DIFF
--- a/khiops/core/internals/filesystems.py
+++ b/khiops/core/internals/filesystems.py
@@ -477,7 +477,7 @@ class LocalFilesystemResource(FilesystemResource):
 
     def copy_from_local(self, local_path):
         directory = os.path.dirname(self.path)
-        if not os.path.isdir(directory):
+        if len(directory) > 0 and not os.path.isdir(directory):
             os.makedirs(directory)
         shutil.copy(local_path, self.path)
 


### PR DESCRIPTION
Fix a border case in the `LocalFileSystem.copy_from_local` where a relative path is given for the target file.

The library would try and fail to create a parent directory named ''

---

### TODO Before Asking for a Review
- [x] Rebase your branch to the latest version of `dev` (or `main` for release PRs)
- [x] Make sure all CI workflows are green
- [ ] When adding a public feature/fix: Update the `Unreleased` section of `CHANGELOG.md` (no date)
- [x] Self-Review: Review "Files Changed" tab and fix any problems you find
- API Docs (only if there are changes in docstrings, rst files or samples):
  - [ ] Check the docs build **without** warning: see the log of the API Docs workflow
  - [ ] Check that your changes render well in HTML: download the API Docs artifact and open `index.html`
  - If there are any problems it is faster to iterate by [building locally the API Docs](../blob/dev/doc/README.md#build-the-documentation)
