### PR TITLE
Revert "Put a workaround to fetch the 0.0.14 version of the s3 driver from github

### DIFF
--- a/packaging/docker/khiopspydev/Dockerfile.rocky
+++ b/packaging/docker/khiopspydev/Dockerfile.rocky
@@ -14,7 +14,8 @@ ARG KHIOPS_REVISION
 RUN true \
   && useradd -rm -d /home/rocky -s /bin/bash -g root -u 1000 rocky \
   # Install git (for khiops-python version calculation), pandoc and pip \
-  && dnf upgrade -y \
+  # --allowerasing is needed to resolve package conflicts \
+  && dnf upgrade -y --allowerasing \
   && dnf search pandoc \
   && dnf install --enablerepo=devel -y \
     git \

--- a/packaging/docker/khiopspydev/Dockerfile.ubuntu
+++ b/packaging/docker/khiopspydev/Dockerfile.ubuntu
@@ -83,8 +83,7 @@ RUN true \
     # Get Linux distribution codename \
     && if [ -f /etc/os-release ]; then . /etc/os-release; fi \
     && wget -O khiops-gcs.deb https://github.com/KhiopsML/khiopsdriver-gcs/releases/download/${KHIOPS_GCS_DRIVER_REVISION}/khiops-driver-gcs_${KHIOPS_GCS_DRIVER_REVISION}-1-${VERSION_CODENAME}.amd64.deb \
-    # A little typo in the artifact name for version 0.0.14 needs fixing that is why a hardcoded version is used here \
-    && wget -O khiops-s3.deb https://github.com/KhiopsML/khiopsdriver-s3/releases/download/${KHIOPS_S3_DRIVER_REVISION}/khiops-driver-s3_0.0.13-1-${VERSION_CODENAME}.amd64.deb \
+    && wget -O khiops-s3.deb https://github.com/KhiopsML/khiopsdriver-s3/releases/download/${KHIOPS_S3_DRIVER_REVISION}/khiops-driver-s3_${KHIOPS_S3_DRIVER_REVISION}-1-${VERSION_CODENAME}.amd64.deb \
     && (dpkg -i --force-all khiops-gcs.deb khiops-s3.deb || true) \
     && apt-get -f -y install \
     && rm -f khiops-gcs.deb khiops-s3.deb \


### PR DESCRIPTION
This reverts commit 22a553ac2de3d48fc2a037bb84bc757fab647087.
(temporary workaround because of a typo in the file names)

---

### TODO Before Asking for a Review
- [x] Rebase your branch to the latest version of `dev` (or `main` for release PRs)
- [ ] Make sure all CI workflows are green
- [ ] When adding a public feature/fix: Update the `Unreleased` section of `CHANGELOG.md` (no date)
- [x] Self-Review: Review "Files Changed" tab and fix any problems you find
- API Docs (only if there are changes in docstrings, rst files or samples):
  - [ ] Check the docs build **without** warning: see the log of the API Docs workflow
  - [ ] Check that your changes render well in HTML: download the API Docs artifact and open `index.html`
  - If there are any problems it is faster to iterate by [building locally the API Docs](../blob/dev/doc/README.md#build-the-documentation)
