### PR TITLE
Fix GitHub / Pip package version coherence check

### DIFF
--- a/.github/workflows/pip.yml
+++ b/.github/workflows/pip.yml
@@ -166,7 +166,7 @@ jobs:
           if [[ "${{ matrix.container }}" == "debian13" ]]; then
             deactivate
           fi
-          echo ${{ github.ref_name }} | tr -d '-' | rev | sed 's/\.//' | rev | \
+          echo ${{ github.ref_name }} | tr -d '-' | rev | sed -E 's/\.([^0-9].*)/\1/' | rev | \
             grep -wq $PACKAGE_VERSION
           if [[ $? -ne 0 ]]
           then


### PR DESCRIPTION
It now works for pre-releases and for releases as well.