### PR TITLE
534 add missing attributes to khiopsregressor

### DIFF
--- a/khiops/sklearn/estimators.py
+++ b/khiops/sklearn/estimators.py
@@ -2172,8 +2172,6 @@ class KhiopsRegressor(RegressorMixin, KhiopsPredictor):
         self : `KhiopsRegressor`
             The calling estimator instance.
         """
-        if self.n_trees > 0:
-            warnings.warn("Khiops does not support n_trees > 0 for regression models.")
         kwargs["categorical_target"] = False
         return super().fit(X, y=y, **kwargs)
 


### PR DESCRIPTION
Add `n_trees`, `n_text_features` and `type_text_features` to the `KhiopsRegressor` class docstring.
Drop spurious unsupported `n_trees` warning on `KhiopsRegressor`.
closes #534 , #520 .

---

### TODO Before Asking for a Review
- [x] Rebase your branch to the latest version of `dev` (or `main` for release PRs)
- [ ] Make sure all CI workflows are green
- [ ] When adding a public feature/fix: Update the `Unreleased` section of `CHANGELOG.md` (no date)
- [x] Self-Review: Review "Files Changed" tab and fix any problems you find
- API Docs (only if there are changes in docstrings, rst files or samples):
  - [ ] Check the docs build **without** warning: see the log of the API Docs workflow
  - [ ] Check that your changes render well in HTML: download the API Docs artifact and open `index.html`
  - If there are any problems it is faster to iterate by [building locally the API Docs](../blob/dev/doc/README.md#build-the-documentation)
