### PR TITLE
Make the default value of `n_features` match the khiops core value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,14 @@
 ## Unreleased
 
 ### Added
-- (`sklearn`) `n_feature_parts` parameter to the supervised estimators 
+- (`sklearn`) `n_feature_parts` parameter to the supervised estimators
+
+### Fixed
+- (`sklearn`) Default value of `n_features` for the supervised estimators
 
 ## 11.0.0.2 - 2026-01-26
 
-## Fixed
+### Fixed
 - (`core`) Samples dir path construction when HOME is a remote path
 
 ## 11.0.0.1 - 2026-01-14

--- a/khiops/sklearn/estimators.py
+++ b/khiops/sklearn/estimators.py
@@ -1188,7 +1188,7 @@ class KhiopsSupervisedEstimator(KhiopsEstimator):
 
     def __init__(
         self,
-        n_features=100,
+        n_features=1000,
         n_trees=10,
         n_text_features=10000,
         type_text_features="words",
@@ -1513,7 +1513,7 @@ class KhiopsPredictor(KhiopsSupervisedEstimator):
 
     def __init__(
         self,
-        n_features=100,
+        n_features=1000,
         n_trees=10,
         n_text_features=10000,
         type_text_features="words",
@@ -1656,7 +1656,7 @@ class KhiopsClassifier(ClassifierMixin, KhiopsPredictor):
 
     Parameters
     ----------
-    n_features : int, default 100
+    n_features : int, default 1000
         Maximum number of features to construct automatically. See
         :doc:`/multi_table_primer` for more details on the multi-table-specific
         features.
@@ -1748,7 +1748,7 @@ class KhiopsClassifier(ClassifierMixin, KhiopsPredictor):
 
     def __init__(
         self,
-        n_features=100,
+        n_features=1000,
         n_pairs=0,
         n_trees=10,
         n_text_features=10000,
@@ -2076,7 +2076,7 @@ class KhiopsRegressor(RegressorMixin, KhiopsPredictor):
 
     Parameters
     ----------
-    n_features : int, default 100
+    n_features : int, default 1000
         Maximum number of features to construct automatically. See
         :doc:`/multi_table_primer` for more details on the multi-table-specific
         features.
@@ -2141,7 +2141,7 @@ class KhiopsRegressor(RegressorMixin, KhiopsPredictor):
 
     def __init__(
         self,
-        n_features=100,
+        n_features=1000,
         n_trees=0,
         n_text_features=10000,
         type_text_features="words",
@@ -2283,7 +2283,7 @@ class KhiopsEncoder(TransformerMixin, KhiopsSupervisedEstimator):
     ----------
     categorical_target : bool, default ``True``
         ``True`` if the target column is categorical.
-    n_features : int, default 100
+    n_features : int, default 1000
         Maximum number of features to construct automatically. See
         :doc:`/multi_table_primer` for more details on the multi-table-specific
         features.
@@ -2390,7 +2390,7 @@ class KhiopsEncoder(TransformerMixin, KhiopsSupervisedEstimator):
     def __init__(
         self,
         categorical_target=True,
-        n_features=100,
+        n_features=1000,
         n_pairs=0,
         n_trees=0,
         n_text_features=10000,

--- a/tests/test_sklearn.py
+++ b/tests/test_sklearn.py
@@ -753,6 +753,7 @@ class KhiopsSklearnParameterPassingTests(unittest.TestCase):
                                 "field_separator": "\t",
                                 "detect_format": False,
                                 "header_line": True,
+                                "max_constructed_variables": 333,
                                 "max_pairs": 1,
                                 "max_trees": 5,
                                 "max_text_features": 300000,
@@ -785,6 +786,7 @@ class KhiopsSklearnParameterPassingTests(unittest.TestCase):
                                 "field_separator": "\t",
                                 "detect_format": False,
                                 "header_line": True,
+                                "max_constructed_variables": 555,
                                 "max_trees": 0,
                                 "max_text_features": 300000,
                                 "text_features": "ngrams",
@@ -813,6 +815,7 @@ class KhiopsSklearnParameterPassingTests(unittest.TestCase):
                                 "field_separator": "\t",
                                 "detect_format": False,
                                 "header_line": True,
+                                "max_constructed_variables": 777,
                                 "max_pairs": 1,
                                 "max_trees": 5,
                                 "max_text_features": 300000,
@@ -1432,6 +1435,7 @@ class KhiopsSklearnParameterPassingTests(unittest.TestCase):
             schema_type="monotable",
             source_type="dataframe",
             extra_estimator_kwargs={
+                "n_features": 333,
                 "n_pairs": 1,
                 "n_trees": 5,
                 "n_text_features": 300000,
@@ -1456,6 +1460,7 @@ class KhiopsSklearnParameterPassingTests(unittest.TestCase):
             schema_type="monotable",
             source_type="dataframe_xy",
             extra_estimator_kwargs={
+                "n_features": 333,
                 "n_pairs": 1,
                 "n_trees": 5,
                 "n_text_features": 300000,
@@ -1519,6 +1524,7 @@ class KhiopsSklearnParameterPassingTests(unittest.TestCase):
             schema_type="monotable",
             source_type="dataframe",
             extra_estimator_kwargs={
+                "n_features": 777,
                 "n_pairs": 1,
                 "n_trees": 5,
                 "n_text_features": 300000,
@@ -1546,6 +1552,7 @@ class KhiopsSklearnParameterPassingTests(unittest.TestCase):
             schema_type="monotable",
             source_type="dataframe_xy",
             extra_estimator_kwargs={
+                "n_features": 777,
                 "n_pairs": 1,
                 "n_trees": 5,
                 "n_text_features": 300000,
@@ -1615,6 +1622,7 @@ class KhiopsSklearnParameterPassingTests(unittest.TestCase):
             schema_type="monotable",
             source_type="dataframe",
             extra_estimator_kwargs={
+                "n_features": 555,
                 "n_selected_features": 1,
                 "n_evaluated_features": 3,
                 "n_text_features": 300000,
@@ -1634,6 +1642,7 @@ class KhiopsSklearnParameterPassingTests(unittest.TestCase):
             schema_type="monotable",
             source_type="dataframe_xy",
             extra_estimator_kwargs={
+                "n_features": 555,
                 "n_selected_features": 1,
                 "n_evaluated_features": 3,
                 "n_text_features": 300000,


### PR DESCRIPTION
- KhiopsClassifier, KhiopsRegressor, KhiopsEncoder


Fixes #543

---

### TODO Before Asking for a Review
- [x] Rebase your branch to the latest version of `main` (or `main-v10`)
- [x] Make sure all CI workflows are green
- [x] When adding a public feature/fix: Update the `Unreleased` section of `CHANGELOG.md` (no date)
- [x] Self-Review: Review "Files Changed" tab and fix any problems you find
- API Docs (only if there are changes in docstrings, rst files or samples):
  - [ ] Check the docs build **without** warning: see the log of the API Docs workflow
  - [ ] Check that your changes render well in HTML: download the API Docs artifact and open `index.html`
  - If there are any problems it is faster to iterate by [building locally the API Docs](../blob/main/doc/README.md#build-the-documentation)
