### PR TITLE
Adapt to scikit-learn 1.8.0

### DIFF
--- a/.github/workflows/pip.yml
+++ b/.github/workflows/pip.yml
@@ -71,7 +71,7 @@ jobs:
       # because the `env` context is only accessible at the step level;
       # hence, it is hard-coded
       image: |-
-        ghcr.io/khiopsml/khiops-python/khiopspydev-${{ matrix.container }}:${{ inputs.image-tag || 'latest' }}
+        ghcr.io/khiopsml/khiops-python/khiopspydev-${{ matrix.container }}:${{ inputs.image-tag || '11.0.0.3' }}
     steps:
       - name: Set parameters as env
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,7 +42,7 @@ jobs:
       # because the `env` context is only accessible at the step level;
       # hence, it is hard-coded
       image: |-
-        ghcr.io/khiopsml/khiops-python/khiopspydev-ubuntu22.04:${{ inputs.image-tag || 'latest' }}
+        ghcr.io/khiopsml/khiops-python/khiopspydev-ubuntu22.04:${{ inputs.image-tag || '11.0.0.3' }}
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -361,7 +361,7 @@ jobs:
       # because the `env` context is only accessible at the step level;
       # hence, it is hard-coded
       image: |-
-        ghcr.io/khiopsml/khiops-python/khiopspydev-${{ matrix.container }}:${{ inputs.image-tag || 'latest' }}
+        ghcr.io/khiopsml/khiops-python/khiopspydev-${{ matrix.container }}:${{ inputs.image-tag || '11.0.0.3' }}
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -5,5 +5,5 @@ nbconvert==6.4.4
 nbformat==5.3.0
 numpydoc>=1.5.0
 pandas>=0.25.3,<=2.3.3
-scikit-learn>=0.22.2,<=1.7.2
+scikit-learn>=1.7.2,<1.9.0
 sphinx-copybutton>=0.5.0

--- a/khiops/sklearn/dataset.py
+++ b/khiops/sklearn/dataset.py
@@ -1077,7 +1077,7 @@ class NumpyTable(DatasetTable):
             raise TypeError(type_error_message("array", array, np.ndarray, Sequence))
 
         # Initialize the members
-        self.data_source = check_array(array, ensure_2d=True, force_all_finite=False)
+        self.data_source = check_array(array, ensure_2d=True, ensure_all_finite=False)
         self.column_ids = column_or_1d(range(self.data_source.shape[1]))
         self.khiops_types = {
             column_id: get_khiops_type(self.data_source.dtype)

--- a/packaging/conda/meta.yaml
+++ b/packaging/conda/meta.yaml
@@ -25,7 +25,7 @@ requirements:
     - python
     - khiops-core =11.0.0
     - pandas >=0.25.3,<=2.3.3
-    - scikit-learn >=0.22.2
+    - scikit-learn>=1.7.2,<1.9.0
   run_constrained:
     # do not necessary use the latest version
     # to avoid undesired breaking changes

--- a/packaging/docker/khiopspydev/Dockerfile.rocky
+++ b/packaging/docker/khiopspydev/Dockerfile.rocky
@@ -21,16 +21,12 @@ RUN true \
     git \
     pandoc \
     wget \
-  # Install Python 3.11 if on Rocky 8 \
-  && if [ "$KHIOPSDEV_OS" = "rocky8" ]; then \
+  # Install Python 3.11 on Rocky 8 or 9 as they come with obsolete versions (<= 3.9) \
+  && if [ "$KHIOPSDEV_OS" = "rocky8" -o "$KHIOPSDEV_OS" = "rocky9" ]; then \
        dnf install -y \
        python3.11 \
        python3.11-pip \
        python3.11-setuptools ; \
-     else \
-       dnf install -y \
-       python3-setuptools \
-       python3-pip ; \
      fi \
   # Get Linux distribution codename \
   && if [ -f /etc/os-release ]; then . /etc/os-release; fi \
@@ -47,14 +43,12 @@ RUN true \
   && module unload mpi \
   # Hard-code OpenMPI module name \
   && module load mpi/openmpi-x86_64 \
-  # Set python to python3.11 and pip to Pip 3.11 on Rocky 8 \
-  # Set python to python3 on Rocky 9 \
-  && if [ "$KHIOPSDEV_OS" = "rocky8" ]; then \
-       alternatives --set python /usr/bin/python3.11 \
-       && alternatives --install /usr/bin/pip pip /usr/bin/pip3.11 1 ; \
-     else \
-       alternatives --install /usr/bin/python python /usr/bin/python3 1 \
-       && alternatives --install /usr/bin/pip pip /usr/bin/pip3 1 ; \
+  # Set python to python3.11 and pip to Pip 3.11 on Rocky 8 and 9 \
+  && if [ "$KHIOPSDEV_OS" = "rocky8" -o "$KHIOPSDEV_OS" = "rocky9" ]; then \
+       alternatives --install /usr/bin/python python /usr/bin/python3.11 2; \
+       alternatives --set python /usr/bin/python3.11; \
+       alternatives --install /usr/bin/pip pip /usr/bin/pip3.11 2; \
+       alternatives --set pip /usr/bin/pip3.11; \
      fi \
   # Install miniforge to have multiple Python versions via Conda \
   && mkdir -p /root/miniforge3 && cd /root/miniforge3 \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,7 +106,7 @@ requires-python = ">=3.8"
 dependencies = [
     # do not use the latest versions, to avoid undesired breaking changes
     "pandas>=0.25.3,<=2.3.3",
-    "scikit-learn>=0.22.2,<=1.7.2",
+    "scikit-learn>=1.7.2,<1.9.0",
 ]
 
 [project.urls]

--- a/tests/test_sklearn.py
+++ b/tests/test_sklearn.py
@@ -18,7 +18,7 @@ from itertools import product
 import numpy as np
 import pandas as pd
 from sklearn.exceptions import NotFittedError
-from sklearn.utils.estimator_checks import check_estimator
+from sklearn.utils.estimator_checks import estimator_checks_generator
 from sklearn.utils.validation import check_is_fitted
 
 import khiops.core as kh
@@ -1784,9 +1784,7 @@ class KhiopsSklearnEstimatorStandardTests(unittest.TestCase):
             # Execute sklearn's estimator test battery
             print("")
             for khiops_estimator in khiops_estimators:
-                for estimator, check in check_estimator(
-                    khiops_estimator, generate_only=True
-                ):
+                for estimator, check in estimator_checks_generator(khiops_estimator):
                     check_name = check.func.__name__
                     if check_name == "check_n_features_in_after_fitting":
                         continue


### PR DESCRIPTION
- Since version 1.7.2 the new parameters or functions are already available so no deprecated calls should remain
- For python 3.10, 1.7.2 is still used
- For python 3.11+, the later 1.8.0+ versions are used

Fixes #519 and #523

---

### TODO Before Asking for a Review
- [x] Rebase your branch to the latest version of `main` (or `main-v10`)
- [x] Make sure all CI workflows are green
- [ ] When adding a public feature/fix: Update the `Unreleased` section of `CHANGELOG.md` (no date)
- [x] Self-Review: Review "Files Changed" tab and fix any problems you find
- API Docs (only if there are changes in docstrings, rst files or samples):
  - [ ] Check the docs build **without** warning: see the log of the API Docs workflow
  - [ ] Check that your changes render well in HTML: download the API Docs artifact and open `index.html`
  - If there are any problems it is faster to iterate by [building locally the API Docs](../blob/main/doc/README.md#build-the-documentation)
