### PR TITLE
Fix and make `LocalFilesystemResource.write` consistent with the other FS (GCS, S3)

### DIFF
--- a/khiops/core/internals/filesystems.py
+++ b/khiops/core/internals/filesystems.py
@@ -463,6 +463,9 @@ class LocalFilesystemResource(FilesystemResource):
                 return local_file.read(size)
 
     def write(self, data):
+        directory = os.path.dirname(self.path)
+        if len(directory) > 0 and not os.path.isdir(directory):
+            os.makedirs(directory)
         with open(self.path, "wb") as output_file:
             output_file.write(data)
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -303,7 +303,14 @@ class KhiopsCoreIOTests(unittest.TestCase):
             ref_kdic = os.path.join(ref_kdic_dir, f"{dictionary}.kdic")
             ref_kdicj = os.path.join(ref_kdicj_dir, f"{dictionary}.kdicj")
             output_kdic = os.path.join(output_kdic_dir, f"{dictionary}.kdic")
+            output_kdic_new_dir = os.path.join(output_kdic_dir, "missing_folder")
+
+            # Cleanup the previous `output_kdic_new_dir` folder (if it exists)
+            shutil.rmtree(output_kdic_new_dir, ignore_errors=True)
+
+            self.assertFalse(os.path.exists(output_kdic_new_dir))
             copy_output_kdic = os.path.join(copy_output_kdic_dir, f"{dictionary}.kdic")
+
             with self.subTest(dictionary=dictionary):
                 if dictionary in dictionaries_warn:
                     with self.assertWarns(UserWarning):
@@ -312,6 +319,11 @@ class KhiopsCoreIOTests(unittest.TestCase):
                     domain = kh.read_dictionary_file(ref_kdicj)
                 domain.export_khiops_dictionary_file(output_kdic)
                 assert_files_equal(self, ref_kdic, output_kdic)
+                domain.export_khiops_dictionary_file(
+                    os.path.join(output_kdic_new_dir, f"{dictionary}.kdic")
+                )
+                # Ensure a missing parent directory is created automatically
+                self.assertTrue(os.path.exists(output_kdic_new_dir))
 
                 domain_copy = domain.copy()
                 domain_copy.export_khiops_dictionary_file(copy_output_kdic)


### PR DESCRIPTION
Before writing the target file, if a folder is missing in the file path, it is automatically created

Fixes #557 

---

### TODO Before Asking for a Review
- [x] Rebase your branch to the latest version of `main` (or `main-v10`)
- [x] Make sure all CI workflows are green
- [ ] When adding a public feature/fix: Update the `Unreleased` section of `CHANGELOG.md` (no date)
- [x] Self-Review: Review "Files Changed" tab and fix any problems you find
- API Docs (only if there are changes in docstrings, rst files or samples):
  - [ ] Check the docs build **without** warning: see the log of the API Docs workflow
  - [ ] Check that your changes render well in HTML: download the API Docs artifact and open `index.html`
  - If there are any problems it is faster to iterate by [building locally the API Docs](../blob/main/doc/README.md#build-the-documentation)
