### PR TITLE
Expose `keep_selected_variables_only` for sklearn predictors (KhiopsClassifier and KhiopsRegressor)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 
 ## Unreleased
 
+### Added
+- (`sklearn`) `keep_selected_variables_only` parameter to the predictors (`KhiopsClassifier` and `KhiopsRegressor`)
+
 ### Changed
 - (`core`) Rename `variable_part_dimensions` to `inner_variable_dimensions` in Coclustering results.
 

--- a/khiops/sklearn/estimators.py
+++ b/khiops/sklearn/estimators.py
@@ -1196,6 +1196,7 @@ class KhiopsSupervisedEstimator(KhiopsEstimator):
         all_possible_pairs=True,
         construction_rules=None,
         n_feature_parts=0,
+        keep_selected_variables_only=True,
         verbose=False,
         output_dir=None,
         auto_sort=True,
@@ -1213,6 +1214,7 @@ class KhiopsSupervisedEstimator(KhiopsEstimator):
         self.all_possible_pairs = all_possible_pairs
         self.construction_rules = construction_rules
         self.n_feature_parts = n_feature_parts
+        self.keep_selected_variables_only = keep_selected_variables_only
         self._original_target_dtype = None
         self._predicted_target_meta_data_tag = None
         self._khiops_baseline_model_prefix = None
@@ -1523,6 +1525,7 @@ class KhiopsPredictor(KhiopsSupervisedEstimator):
         all_possible_pairs=True,
         construction_rules=None,
         n_feature_parts=0,
+        keep_selected_variables_only=True,
         verbose=False,
         output_dir=None,
         auto_sort=True,
@@ -1536,6 +1539,7 @@ class KhiopsPredictor(KhiopsSupervisedEstimator):
             all_possible_pairs=all_possible_pairs,
             construction_rules=construction_rules,
             n_feature_parts=n_feature_parts,
+            keep_selected_variables_only=keep_selected_variables_only,
             verbose=verbose,
             output_dir=output_dir,
             auto_sort=auto_sort,
@@ -1703,6 +1707,8 @@ class KhiopsClassifier(ClassifierMixin, KhiopsPredictor):
     group_target_value : bool, default ``False``
         Allows grouping of the target values in classification. It can substantially
         increase the training time.
+    keep_selected_variables_only : bool, default ``True``
+        Keeps only predictor-selected variables in the supervised analysis report.
     verbose : bool, default ``False``
         If ``True`` it prints debug information and it does not erase temporary files
         when fitting, predicting or transforming.
@@ -1760,6 +1766,7 @@ class KhiopsClassifier(ClassifierMixin, KhiopsPredictor):
         construction_rules=None,
         n_feature_parts=0,
         group_target_value=False,
+        keep_selected_variables_only=True,
         verbose=False,
         output_dir=None,
         auto_sort=True,
@@ -1773,6 +1780,7 @@ class KhiopsClassifier(ClassifierMixin, KhiopsPredictor):
             n_evaluated_features=n_evaluated_features,
             construction_rules=construction_rules,
             n_feature_parts=n_feature_parts,
+            keep_selected_variables_only=keep_selected_variables_only,
             verbose=verbose,
             output_dir=output_dir,
             auto_sort=auto_sort,
@@ -2105,6 +2113,8 @@ class KhiopsRegressor(RegressorMixin, KhiopsPredictor):
     n_feature_parts : int, default 0
         Maximum number of variable parts produced by preprocessing methods. If equal
         to 0 it is automatically calculated.
+    keep_selected_variables_only : bool, default ``True``
+        Keeps only predictor-selected variables in the supervised analysis report.
     verbose : bool, default ``False``
         If ``True`` it prints debug information and it does not erase temporary files
         when fitting, predicting or transforming.
@@ -2149,6 +2159,7 @@ class KhiopsRegressor(RegressorMixin, KhiopsPredictor):
         n_evaluated_features=0,
         construction_rules=None,
         n_feature_parts=0,
+        keep_selected_variables_only=True,
         verbose=False,
         output_dir=None,
         auto_sort=True,
@@ -2162,6 +2173,7 @@ class KhiopsRegressor(RegressorMixin, KhiopsPredictor):
             n_evaluated_features=n_evaluated_features,
             construction_rules=construction_rules,
             n_feature_parts=n_feature_parts,
+            keep_selected_variables_only=keep_selected_variables_only,
             verbose=verbose,
             output_dir=output_dir,
             auto_sort=auto_sort,

--- a/tests/test_sklearn.py
+++ b/tests/test_sklearn.py
@@ -766,6 +766,7 @@ class KhiopsSklearnParameterPassingTests(unittest.TestCase):
                                 "max_parts": 3,
                                 "group_target_value": False,
                                 "additional_data_tables": {},
+                                "keep_selected_variables_only": False,
                             }
                         },
                         "predict": {
@@ -794,6 +795,7 @@ class KhiopsSklearnParameterPassingTests(unittest.TestCase):
                                 "max_evaluated_variables": 3,
                                 "construction_rules": ["TableMode", "TableSelection"],
                                 "max_parts": 5,
+                                "keep_selected_variables_only": False,
                                 "additional_data_tables": {},
                             }
                         },
@@ -1449,6 +1451,7 @@ class KhiopsSklearnParameterPassingTests(unittest.TestCase):
                 "construction_rules": ["TableMode", "TableSelection"],
                 "n_feature_parts": 3,
                 "group_target_value": False,
+                "keep_selected_variables_only": False,
             },
         )
 
@@ -1474,6 +1477,7 @@ class KhiopsSklearnParameterPassingTests(unittest.TestCase):
                 "construction_rules": ["TableMode", "TableSelection"],
                 "n_feature_parts": 3,
                 "group_target_value": False,
+                "keep_selected_variables_only": False,
             },
         )
 
@@ -1631,6 +1635,7 @@ class KhiopsSklearnParameterPassingTests(unittest.TestCase):
                 "type_text_features": "ngrams",
                 "construction_rules": ["TableMode", "TableSelection"],
                 "n_feature_parts": 5,
+                "keep_selected_variables_only": False,
             },
         )
 
@@ -1651,6 +1656,7 @@ class KhiopsSklearnParameterPassingTests(unittest.TestCase):
                 "type_text_features": "ngrams",
                 "construction_rules": ["TableMode", "TableSelection"],
                 "n_feature_parts": 5,
+                "keep_selected_variables_only": False,
             },
         )
 


### PR DESCRIPTION
Fixes #559

---

### TODO Before Asking for a Review
- [x] Rebase your branch to the latest version of `main` (or `main-v10`)
- [x] Make sure all CI workflows are green
- [x] When adding a public feature/fix: Update the `Unreleased` section of `CHANGELOG.md` (no date)
- [x] Self-Review: Review "Files Changed" tab and fix any problems you find
- API Docs (only if there are changes in docstrings, rst files or samples):
  - [x] Check the docs build **without** warning: see the log of the API Docs workflow
  - [x] Check that your changes render well in HTML: download the API Docs artifact and open `index.html`
  - If there are any problems it is faster to iterate by [building locally the API Docs](../blob/main/doc/README.md#build-the-documentation)
