### PR TITLE
Support for Azure storage

### DIFF
--- a/.github/workflows/dev-docker.yml
+++ b/.github/workflows/dev-docker.yml
@@ -5,8 +5,9 @@ env:
   DEFAULT_IMAGE_INCREMENT: 0
   DEFAULT_SERVER_REVISION: main
   DEFAULT_PYTHON_VERSIONS: 3.10 3.11 3.12 3.13 3.14
-  DEFAULT_KHIOPS_GCS_DRIVER_REVISION: 0.0.14
-  DEFAULT_KHIOPS_S3_DRIVER_REVISION: 0.0.14
+  DEFAULT_KHIOPS_GCS_DRIVER_REVISION: 0.0.16
+  DEFAULT_KHIOPS_S3_DRIVER_REVISION: 0.0.15
+  DEFAULT_KHIOPS_AZURE_DRIVER_REVISION: 0.0.6  # XXX : to modify soon
 on:
   pull_request:
     paths: [packaging/docker/khiopspydev/Dockerfile.*, .github/workflows/dev-docker.yml]
@@ -38,12 +39,16 @@ on:
         description: Khiops Server Revision
       khiops-gcs-driver-revision:
         type: string
-        default: 0.0.14
+        default: 0.0.16
         description: Driver version for Google Cloud Storage remote files
       khiops-s3-driver-revision:
         type: string
-        default: 0.0.14
+        default: 0.0.15
         description: Driver version for AWS-S3 remote files
+      khiops-azure-driver-revision:
+        type: string
+        default: 0.0.6  # XXX : to modify soon
+        description: Driver version for Azure remote files and blobs
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
@@ -67,6 +72,7 @@ jobs:
           echo "IMAGE_URL=ghcr.io/khiopsml/khiops-python/khiopspydev-${{ matrix.khiopsdev-os }}" >> "$GITHUB_ENV"
           echo "KHIOPS_GCS_DRIVER_REVISION=${{ inputs.khiops-gcs-driver-revision || env.DEFAULT_KHIOPS_GCS_DRIVER_REVISION }}" >> "$GITHUB_ENV"
           echo "KHIOPS_S3_DRIVER_REVISION=${{ inputs.khiops-s3-driver-revision || env.DEFAULT_KHIOPS_S3_DRIVER_REVISION }}" >> "$GITHUB_ENV"
+          echo "KHIOPS_AZURE_DRIVER_REVISION=${{ inputs.khiops-azure-driver-revision || env.DEFAULT_KHIOPS_AZURE_DRIVER_REVISION }}" >> "$GITHUB_ENV"
       - name: Checkout khiops-python sources
         uses: actions/checkout@v4
       - name: Set up Docker Buildx
@@ -105,6 +111,7 @@ jobs:
             "PYTHON_VERSIONS=${{ inputs.python-versions || env.DEFAULT_PYTHON_VERSIONS }}"
             "KHIOPS_GCS_DRIVER_REVISION=${{ env.KHIOPS_GCS_DRIVER_REVISION }}"
             "KHIOPS_S3_DRIVER_REVISION=${{ env.KHIOPS_S3_DRIVER_REVISION }}"
+            "KHIOPS_AZURE_DRIVER_REVISION=${{ env.KHIOPS_AZURE_DRIVER_REVISION }}"
           tags: ${{ env.DOCKER_IMAGE_TAGS }}
           # Push only on manual request
           push: ${{ inputs.push || false }}

--- a/.github/workflows/dev-docker.yml
+++ b/.github/workflows/dev-docker.yml
@@ -28,7 +28,7 @@ on:
       set-latest:
         type: boolean
         default: false
-        description: Set as 'latest'
+        description: Set as 'latest' (if the current branch is 'main')
       python-versions:
         type: string
         default: 3.10 3.11 3.12 3.13 3.14

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -138,14 +138,22 @@ jobs:
           echo "Generated AWS configuration..."
           cat  ${GITHUB_WORKSPACE}/.aws/configuration
           /scripts/run_fake_remote_file_servers.sh .  # launch the servers in the background
+
           # Set environment variables for the tests with GCS
           GCS_BUCKET_NAME=data-test-khiops-driver-gcs/khiops_data
           GCS_DRIVER_LOGLEVEL=info  # set to debug for diagnosis
+
           # Set environment variables for the tests with S3
           S3_DRIVER_LOGLEVEL=info  # set to debug for diagnosis
           S3_BUCKET_NAME=s3-bucket
           AWS_SHARED_CREDENTIALS_FILE=${{ github.workspace }}/.aws/credentials
           AWS_CONFIG_FILE=${{ github.workspace }}/.aws/configuration
+
+          # Set environment variables for the tests with Azure
+          AZURE_STORAGE_CONNECTION_STRING='${{ secrets.AZURE_CONNECTION_STRING }}'
+          CLOUD_BLOB_URI_PREFIX=${{ vars.CLOUD_BLOB_URI_PREFIX }}
+          CLOUD_FILE_URI_PREFIX=${{ vars.CLOUD_FILE_URI_PREFIX }}
+                    
           # Persist environment variables for subsequent steps
           echo "GCS_BUCKET_NAME=${GCS_BUCKET_NAME}" >> "$GITHUB_ENV"
           echo "GCS_DRIVER_LOGLEVEL=${GCS_DRIVER_LOGLEVEL}" >> "$GITHUB_ENV"
@@ -153,6 +161,9 @@ jobs:
           echo "S3_BUCKET_NAME=${S3_BUCKET_NAME}" >> "$GITHUB_ENV"
           echo "AWS_SHARED_CREDENTIALS_FILE=${AWS_SHARED_CREDENTIALS_FILE}" >> "$GITHUB_ENV"
           echo "AWS_CONFIG_FILE=${AWS_CONFIG_FILE}" >> "$GITHUB_ENV"
+          echo "AZURE_STORAGE_CONNECTION_STRING=${AZURE_STORAGE_CONNECTION_STRING}" >> "$GITHUB_ENV"
+          echo "CLOUD_BLOB_URI_PREFIX=${CLOUD_BLOB_URI_PREFIX}" >> "$GITHUB_ENV"
+          echo "CLOUD_FILE_URI_PREFIX=${CLOUD_FILE_URI_PREFIX}" >> "$GITHUB_ENV"
       - name: Authenticate to GCP using "Workload Identity Federation"
         if: env.SKIP_EXPENSIVE_TESTS != 'true'
         # For integration tests on GCS we use a real Google account

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -78,39 +78,27 @@ jobs:
         run: |
           CONDA="/root/miniforge3/bin/conda"
 
-          # Native Khiops-based Conda environment, and
-          # `khiops-core`-based Conda environment
-          CONDA_ENVS="py${{ matrix.python-version }} py${{ matrix.python-version }}_conda"
-          for CONDA_ENV in $CONDA_ENVS
-          do
-            mkdir -p -m u+rwx reports/"$CONDA_ENV"
+          # Native Khiops-based Conda environment (to test in a specific python version)
+          CONDA_ENV=py${{ matrix.python-version }}
+          mkdir -p -m u+rwx reports/"$CONDA_ENV"
 
-            # install within the conda environments without activating them
-            $CONDA install -y -n "$CONDA_ENV" unittest-xml-reporting
-            $CONDA install -y -n "$CONDA_ENV" --file test-requirements.txt
-          done
+          # install within the conda environments without activating them
+          $CONDA install -y -n "$CONDA_ENV" unittest-xml-reporting
+          $CONDA install -y -n "$CONDA_ENV" --file test-requirements.txt
       - name: Install khiops-python dependencies
         if: success() || failure()
         run: |
-          # The following git command is required,
-          # as the Git repository is in a directory the current user does not own,
-          # Python versioneer fails to compute the current version correctly otherwise
-          git config --global --add safe.directory $(realpath .)
           CONDA="/root/miniforge3/bin/conda"
-          # Native Khiops-based Conda environment, and
-          # `khiops-core`-based Conda environment
-          CONDA_ENVS="py${{ matrix.python-version }} py${{ matrix.python-version }}_conda"
-          for CONDA_ENV in $CONDA_ENVS
-          do
-            # Since Python 3.13, setuptools is not installed automatically anymore
-            $CONDA install -y -n "$CONDA_ENV" setuptools
+          # Native Khiops-based Conda environment (to test in a specific python version)          
+          CONDA_ENV=py${{ matrix.python-version }}
+          # Since Python 3.13, setuptools is not installed automatically anymore
+          $CONDA install -y -n "$CONDA_ENV" setuptools
 
-            # Add homogeneous TOML support (Python >= 3.12 has standard tomllib)
-            $CONDA install -y -n "$CONDA_ENV" tomli
-            $CONDA run --no-capture-output -n "$CONDA_ENV" python scripts/extract_dependencies_from_pyproject_toml.py -f "pyproject.toml" > requires.txt
-            $CONDA install -y -n "$CONDA_ENV" `cat requires.txt`
-            rm -f requires.txt
-          done
+          # Add homogeneous TOML support (Python >= 3.12 has standard tomllib)
+          $CONDA install -y -n "$CONDA_ENV" tomli
+          $CONDA run --no-capture-output -n "$CONDA_ENV" python scripts/extract_dependencies_from_pyproject_toml.py -f "pyproject.toml" > requires.txt
+          $CONDA install -y -n "$CONDA_ENV" `cat requires.txt`
+          rm -f requires.txt
       - name: Configure Expensive Tests Setting
         # Skip expensive tests by default, unless on the `main-v10` or `main` branches
         if: github.ref != 'main-v10' && github.ref != 'main' && ! inputs.run-expensive-tests
@@ -197,23 +185,17 @@ jobs:
           # version is retrieved
           git config --global --add safe.directory $(realpath .)
           CONDA="/root/miniforge3/bin/conda"
-          # Native Khiops-based Conda environment, and
-          # `khiops-core`-based Conda environment
-          CONDA_ENVS="py${{ matrix.python-version }} py${{ matrix.python-version }}_conda"
-          for CONDA_ENV in $CONDA_ENVS
-          do
-            $CONDA run --no-capture-output -n "$CONDA_ENV" coverage run -m xmlrunner -o "reports/$CONDA_ENV" -v
-            $CONDA run --no-capture-output -n "$CONDA_ENV" coverage report -m
-            $CONDA run --no-capture-output -n "$CONDA_ENV" coverage xml -o "reports/$CONDA_ENV/py-coverage.xml"
-          done
+          # Native Khiops-based Conda environment (to test in a specific python version)          
+          CONDA_ENV=py${{ matrix.python-version }}
+          $CONDA run --no-capture-output -n "$CONDA_ENV" coverage run -m xmlrunner -o "reports/$CONDA_ENV" -v
+          $CONDA run --no-capture-output -n "$CONDA_ENV" coverage report -m
+          $CONDA run --no-capture-output -n "$CONDA_ENV" coverage xml -o "reports/$CONDA_ENV/py-coverage.xml"
       - name: Display Test Reports
         if: success() || failure()
         uses: dorny/test-reporter@v1
         with:
           name: Run Tests ${{ matrix.python-version }}
-          path: >-
-            reports/py${{ matrix.python-version }}/TEST-tests.*.*.xml,
-            reports/py${{ matrix.python-version }}_conda/TEST-tests.*.*.xml
+          path: reports/py${{ matrix.python-version }}/TEST-tests.*.*.xml
           reporter: java-junit
           path-replace-backslashes: 'true'  # Necessary for windows paths
           fail-on-error: 'false'
@@ -225,8 +207,6 @@ jobs:
           path: |-
             reports/py${{ matrix.python-version }}/TEST-tests.*.*.xml
             reports/py${{ matrix.python-version }}/py-coverage.xml
-            reports/py${{ matrix.python-version }}_conda/TEST-tests.*.*.xml
-            reports/py${{ matrix.python-version }}_conda/py-coverage.xml
             tests/resources/scenario_generation/*/ref/*._kh
             tests/resources/scenario_generation/*/output/*._kh
             tests/resources/*/output_reports/*.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Added
 - (`sklearn`) `keep_selected_variables_only` parameter to the predictors (`KhiopsClassifier` and `KhiopsRegressor`)
+- (General) Support for Azure storage
 
 ### Changed
 - (`core`) Rename `variable_part_dimensions` to `inner_variable_dimensions` in Coclustering results.

--- a/khiops/core/internals/filesystems.py
+++ b/khiops/core/internals/filesystems.py
@@ -5,12 +5,12 @@
 # see the "LICENSE.md" file for more details.                                        #
 ######################################################################################
 """Classes to interact with local and remote filesystems"""
-
 import json
 import os
 import shutil
 import warnings
 from abc import ABC, abstractmethod
+from functools import cached_property
 from pathlib import Path
 from urllib.parse import urlparse
 
@@ -37,6 +37,18 @@ try:
     gcs_import_error = None
 except ImportError as import_error:
     gcs_import_error = import_error
+
+# Import azure packages if available
+# Delay an ImportError raising to an instantiation of the resource
+try:
+    from azure.core import credentials, utils
+
+    # pylint: disable=redefined-outer-name
+    from azure.storage import blob, fileshare
+
+    azure_import_error = None
+except ImportError as import_error:
+    azure_import_error = import_error
 
 # pylint: enable=invalid-name
 
@@ -76,6 +88,7 @@ def create_resource(uri_or_path):
         - ``file`` or empty: Local filesystem resource
         - ``s3``: Amazon S3 resource
         - ``gs``: Google Cloud Storage resource
+        - ``https``: Azure Storage resource (files or blobs)
 
     Returns
     -------
@@ -94,6 +107,19 @@ def create_resource(uri_or_path):
                 return AmazonS3Resource(uri_or_path)
             elif uri_info.scheme == "gs":
                 return GoogleCloudStorageResource(uri_or_path)
+            elif uri_info.scheme == "https":
+                # Create the corresponding instance of Azure storage resource
+                # based on a well-known name pattern of the uri netloc.
+                # Among all the Azure storages, Khiops supports only
+                # (via its specific driver):
+                # - Files
+                # - Blobs (Binary Large Objects)
+                if uri_info.netloc.endswith(".file.core.windows.net"):
+                    # netloc of a file share
+                    return AzureStorageFileResource(uri_or_path)
+                else:
+                    # netloc of a blob
+                    return AzureStorageBlobResource(uri_or_path)
             elif scheme == "file":
                 # Reject URI if authority is not empty
                 if uri_info.netloc:
@@ -503,7 +529,7 @@ class LocalFilesystemResource(FilesystemResource):
 class GoogleCloudStorageResource(FilesystemResource):
     """Google Cloud Storage Resource
 
-    By default it reads the configuration from standard location.
+    By default, it reads the configuration from standard location.
     """
 
     def __init__(self, uri):
@@ -733,3 +759,307 @@ class AmazonS3Resource(FilesystemResource):
 
 
 # pylint: enable=no-member
+
+
+class AzureStorageResourceMixin:
+    """Azure compatible Storage Resource Mixin
+
+    See `AzureStorageFileResource` and `AzureStorageBlobResource` for more details.
+
+    """
+
+    def __init__(self, uri):
+        """
+        Azure Storage Resource initializer common to Files and Blobs
+        """
+
+        # Stop initialization if Azure modules are not available
+        if azure_import_error is not None:
+            warnings.warn(
+                "Could not import azure modules. "
+                "Make sure you have installed the azure.core, "
+                "azure.storage.fileshare and azure.storage.blob packages to "
+                "access Azure Storage files."
+            )
+            raise azure_import_error
+
+        super().__init__(uri)
+
+        if len(self.uri_parts) < 2:
+            # parts[0] contains the "share name" (for file shares)
+            # or "container name" (for blobs)
+            # parts[1:] contains the remaining of the path
+            raise ValueError(
+                f"Invalid Azure Resource URI '{uri}'. "
+                "The allowed patterns are: \n"
+                "- File : https://<storage-account-name>.file.core.windows.net/"
+                "<share name>/<0 to n folder name(s)>/<file name>\n"
+                "- Blob : https://<storage-account-name>.blob.core.windows.net/"
+                "<container name>/<0 to n virtual folder name(s)>/<blob name>"
+            )
+
+        # Create the authentication object using the connection string
+        connection_string = os.environ.get("AZURE_STORAGE_CONNECTION_STRING")
+        mappings = utils.parse_connection_string(connection_string)
+        self.credential = credentials.AzureNamedKeyCredential(
+            mappings.get("accountname"), mappings.get("accountkey")
+        )
+
+    def create_child(self, file_name):
+        return create_resource(child_uri_info(self.uri_info, file_name).geturl())
+
+    def create_parent(self, file_name):  # pylint: disable=unused-argument
+        return create_resource(parent_uri_info(self.uri_info).geturl())
+
+    def _uri_parts(self):
+        return [part for part in self.uri_info.path.split("/") if len(part) > 0]
+
+    @cached_property
+    def uri_parts(self):
+        """Build a list of path parts from a path as a str"""
+        return self._uri_parts()
+
+
+class AzureStorageFileResource(AzureStorageResourceMixin, FilesystemResource):
+    """Azure compatible Storage File Resource
+
+    As a prerequisite, the remote storage account and "file share" on Azure
+    MUST have been created by the user.
+
+    For shared Files, the URI pattern of a resource is the following :
+    https://<storage-account-name>.file.core.windows.net/<share name>/...
+                                                <0 to n folder name(s)>/<file name>
+    The first name after the netloc is the "share name" not a simple "folder name".
+
+    By default, this resource reads the configuration from standard location
+    (environment variables for the moment)
+    """
+
+    def __init__(self, uri):
+        """
+        Azure Storage Resource initializer for Files
+        """
+        super().__init__(uri)
+
+        share_url = (
+            f"{self.uri_info.scheme}://{self.uri_info.netloc}/" f"{self.uri_parts[0]}"
+        )
+        # Instantiate a `ShareClient` and attach it to the current instance.
+        self.azure_share_client = fileshare.ShareClient.from_share_url(
+            share_url=share_url, credential=self.credential
+        )
+
+        self.relative_remaining_path = "/".join(self.uri_parts[1:])
+
+        # Instantiate a `ShareFileClient` and attach it to the current instance.
+        self.file_share_client = self.azure_share_client.get_file_client(
+            self.relative_remaining_path
+        )
+
+        # Instantiate a `ShareDirectoryClient` and attach it to the current instance.
+        self.directory_share_client = self.azure_share_client.get_directory_client(
+            self.relative_remaining_path
+        )
+
+    def write(self, data):
+        # In order to be consistent with the other storage implementations,
+        # if the parent directories are missing they are created one by one.
+        relative_folders_hierarchy = os.path.dirname(self.relative_remaining_path)
+        self._create_the_whole_folders_hierarchy(relative_folders_hierarchy)
+
+        self.file_share_client.upload_file(data)
+
+    def exists(self):
+        """Check if the target resource exists (file or directory)"""
+
+        # Calls to `ShareFileClient` and `ShareDirectoryClient` are required
+        # because :
+        # - the check against `file_share_client` is ``False``
+        #   if the target is a directory.
+        # - the check against `directory_share_client` is ``False``
+        #   if the target is a file.
+        return self.file_share_client.exists() or self.directory_share_client.exists()
+
+    def remove(self):
+        """Remove the target resource either it is a file or a directory.
+        If an error occurs an exception is raised.
+        """
+
+        # Attempt to delete a file first; if it fails, attempt to delete a directory;
+        try:
+            self.file_share_client.delete_file()
+        # pylint: disable=broad-exception-caught
+        except Exception as file_delete_error:
+            try:
+                self.directory_share_client.delete_directory()
+            # pylint: disable=broad-exception-caught
+            except Exception as directory_delete_error:
+                raise RuntimeError(
+                    str(file_delete_error) + " " + str(directory_delete_error)
+                ) from None
+
+    def copy_from_local(self, local_path):
+        # In order to be consistent with the other storage implementations,
+        # if the parent directories are missing they are created one by one.
+        relative_folders_hierarchy = os.path.dirname(self.relative_remaining_path)
+        self._create_the_whole_folders_hierarchy(relative_folders_hierarchy)
+
+        self.file_share_client.upload_file(read(local_path))
+
+    def copy_to_local(self, local_path):
+        data = self.file_share_client.download_file()
+        with open(local_path, "wb") as output_file:
+            data.readinto(output_file)
+
+    def list_dir(self):
+        """List the files (not the directories) of the current directory
+        Notes:
+            This is not a recursive listing operation
+        """
+
+        return [
+            item["name"]
+            for item in self.directory_share_client.list_directories_and_files()
+            if not item["is_directory"]
+        ]
+
+    def make_dir(self):
+        # To avoid any exception while attempting to create an existing directory,
+        # that would occur otherwise, its existence is first checked
+
+        if not self.directory_share_client.exists():
+            self.azure_share_client.create_directory(self.relative_remaining_path)
+
+    def read(self, size=None):
+        return self.file_share_client.download_file(length=size).readall()
+
+    def _create_the_whole_folders_hierarchy(self, relative_folders_hierarchy):
+        """
+        Create the whole folders hierarchy in checking and
+        creating each parent if needed
+        """
+        parts = relative_folders_hierarchy.split("/")
+        current_hierarchy = ""
+        for current_folder in parts:
+            current_hierarchy += current_folder + "/"
+            directory_share_client = self.azure_share_client.get_directory_client(
+                current_hierarchy
+            )
+            if not directory_share_client.exists():
+                self.azure_share_client.create_directory(current_hierarchy)
+
+
+class AzureStorageBlobResource(AzureStorageResourceMixin, FilesystemResource):
+    """Azure compatible Storage Blob Resource
+
+    As a prerequisite, the remote storage account and the blob "container" on Azure
+    MUST have been created by the user.
+
+    For blobs, the URI pattern of a resource is the following:
+    https://<storage-account-name>.blob.core.windows.net/<container name>/...
+                                        <0 to n virtual folder name(s)>/<blob name>
+    The "virtual folder names" are part of the blob name but can help simulate
+    a folder hierarchy.
+    The first name after the netloc is the "container name" not a simple
+    "virtual folder name".
+
+    By default, this resource reads the configuration from standard location
+    (environment variables for the moment)
+    """
+
+    def __init__(self, uri):
+        """
+        Azure Storage Resource initializer for Blobs
+        """
+        super().__init__(uri)
+
+        # For blobs : most of the time, there is no need to distinguish
+        # between `container_url`
+        # and the remaining parts of the path because the `BlobClient` knows
+        # how to handle with absolute paths.
+        # But for blobs listing only, a `ContainerClient` is needed.
+        # Therefore, the `container_url` must still be built.
+        container_url = (
+            f"{self.uri_info.scheme}://"
+            f"{self.uri_info.netloc}/"
+            f"{self.uri_parts[0]}"
+        )
+
+        # Instantiate a `ContainerClient` and attach it to the current instance.
+        self.azure_blob_container_client = blob.ContainerClient.from_container_url(
+            container_url=container_url, credential=self.credential
+        )
+
+        # Instantiate a `BlobClient` and attach it to the current instance.
+        self.azure_blob_client = blob.BlobClient.from_blob_url(
+            blob_url=self.uri_info.geturl(), credential=self.credential
+        )
+
+        # For blobs the client will manage most of the time with absolute paths
+        # except when listing blobs of a "virtual folder" where is field this used.
+        self.relative_remaining_path = "/".join(self.uri_parts[1:])
+
+    def read(self, size=None):
+        return self.azure_blob_client.download_blob(length=size).readall()
+
+    def write(self, data):
+        # In order to be consistent with the other drivers,
+        # this method will overwrite the destination blob if it exists.
+        # This is not the default behavior.
+        self.azure_blob_client.upload_blob(data, overwrite=True)
+
+    def exists(self):
+        # As the virtual folder names are part of the blob name,
+        # there is no such test like checking a virtual folder existence.
+        # Only a blob existence is checked here.
+        return self.azure_blob_client.exists()
+
+    def remove(self):
+        # As the virtual folder names are part of the blob name,
+        # there is no such action like removing a virtual folder.
+        # Only a blob removal is done here.
+        self.azure_blob_client.delete_blob()
+
+    def copy_from_local(self, local_path):
+        # In order to be consistent with the other drivers,
+        # this method will overwrite the destination blob if it exists.
+        # This is not the default behavior.
+        # Moreover, if the virtual folders hierarchy does not exist
+        # it is created automatically as it is part of the blob name.
+        self.azure_blob_client.upload_blob(read(local_path), overwrite=True)
+
+    def copy_to_local(self, local_path):
+        data = self.azure_blob_client.download_blob()
+        with open(local_path, "wb") as output_file:
+            data.readinto(output_file)
+
+    def list_dir(self):
+        """
+        List the files of the current directory
+        """
+        # By default, the sdk will list all the blobs belonging to the container.
+        # An extract filter is then required to simulate a directory listing.
+        # Moreover, the virtual folders hierarchy must be deleted from the result.
+        virtual_folder_hierarchy = self.relative_remaining_path
+        if not virtual_folder_hierarchy.endswith("/"):
+            # Normalize the folder hierarchy with a trailing '/'
+            virtual_folder_hierarchy += "/"
+        len_virtual_folder_hierarchy = len(virtual_folder_hierarchy)
+        return [
+            item[len_virtual_folder_hierarchy:]
+            for item in self.azure_blob_container_client.list_blob_names(
+                # Keep only the blobs belonging to the "virtual folder"
+                name_starts_with=self.relative_remaining_path,
+            )
+        ]
+
+    def make_dir(self):
+        warnings.warn(
+            "'make_dir' is a non-operation on Azure Storage for Blobs. "
+            "See the documentation at "
+            "https://learn.microsoft.com/en-us/rest/api/storageservices/"
+            "operations-on-containers and "
+            "https://learn.microsoft.com/en-us/rest/api/storageservices/"
+            "naming-and-referencing-containers--blobs--and-metadata#blob-names "
+            "(a virtual hierarchy can be created in naming blobs)"
+        )

--- a/packaging/docker/khiopspydev/Dockerfile.debian
+++ b/packaging/docker/khiopspydev/Dockerfile.debian
@@ -49,6 +49,7 @@ RUN true \
 ARG PYTHON_VERSIONS
 ARG KHIOPS_GCS_DRIVER_REVISION
 ARG KHIOPS_S3_DRIVER_REVISION
+ARG KHIOPS_AZURE_DRIVER_REVISION
 
 # Install Conda packages
 # Use `rc` label for alpha or RC khiops-core pre-releases
@@ -73,7 +74,9 @@ RUN true \
         # remote files drivers installed in the conda environment \
         $CONDA install -y -n py${version}_conda \
         khiops-driver-s3==${KHIOPS_S3_DRIVER_REVISION} \
-        khiops-driver-gcs==${KHIOPS_GCS_DRIVER_REVISION}; \
+        khiops-driver-gcs==${KHIOPS_GCS_DRIVER_REVISION} \
+        # XXX hardcoded version because the latest version is not released on conda-forge \
+        khiops-driver-azure==0.0.5; \
     done; \
     # Install Khiops from a different major version in a dedicated conda environment \
     # The python interpreter version of the base environment is used as no specific version is given \
@@ -94,9 +97,11 @@ RUN true \
     # Force the installation of the debian 12 versions (bookworm)
     && wget -O khiops-gcs.deb https://github.com/KhiopsML/khiopsdriver-gcs/releases/download/${KHIOPS_GCS_DRIVER_REVISION}/khiops-driver-gcs_${KHIOPS_GCS_DRIVER_REVISION}-1-bookworm.amd64.deb \
     && wget -O khiops-s3.deb https://github.com/KhiopsML/khiopsdriver-s3/releases/download/${KHIOPS_S3_DRIVER_REVISION}/khiops-driver-s3_${KHIOPS_S3_DRIVER_REVISION}-1-bookworm.amd64.deb \
-    && (dpkg -i --force-all khiops-gcs.deb khiops-s3.deb || true) \
+    # XXX There is a typo in the latest release tag. Until it is fixed, we need to use the hardcoded folder name
+    && wget -O khiops-azure.deb https://github.com/KhiopsML/khiopsdriver-azure/releases/download/0.0.7/khiops-driver-azure_${KHIOPS_AZURE_DRIVER_REVISION}-1-bookworm.amd64.deb \
+    && (dpkg -i --force-all khiops-gcs.deb khiops-s3.deb khiops-azure.deb || true) \
     && apt-get -f -y install \
-    && rm -f khiops-gcs.deb khiops-s3.deb \
+    && rm -f khiops-gcs.deb khiops-s3.deb khiops-azure.deb \
     && true
 
 FROM ghcr.io/khiopsml/khiops-server:${SERVER_REVISION} AS server

--- a/packaging/docker/khiopspydev/Dockerfile.debian
+++ b/packaging/docker/khiopspydev/Dockerfile.debian
@@ -44,44 +44,28 @@ RUN true \
   && rm -rf ./khiops \
   && true
 
-# set up all the supported Python environments under conda (for the unit tests)
+# set up all the supported Python environments under Conda (for the unit tests)
 # relying on a variable containing all the versions
 ARG PYTHON_VERSIONS
 ARG KHIOPS_GCS_DRIVER_REVISION
 ARG KHIOPS_S3_DRIVER_REVISION
 ARG KHIOPS_AZURE_DRIVER_REVISION
 
-# Install Conda packages
-# Use `rc` label for alpha or RC khiops-core pre-releases
+# Initialize all the Conda environments
 RUN true \
   && export CONDA="/root/miniforge3/bin/conda" \
-  && /bin/bash -c 'if [[ $(echo ${KHIOPS_REVISION} | grep -E ".*-(a|rc)\.[0-9]+") ]]; then \
-       export RC_LABEL="conda-forge/label/rc::"; \
-     else \
-       export RC_LABEL=""; \
-     fi; \
+  && /bin/bash -c ' \
     # Update conda to the latest version \
     $CONDA update -n base conda; \
     for version in ${PYTHON_VERSIONS}; \
     do \
-        CONDA_ENVS="py${version} py${version}_conda"; \
-        for CONDA_ENV in $CONDA_ENVS; \
-        do \
-            $CONDA create -y -n $CONDA_ENV python=${version}; \
-        done; \
-        # khiops core \
-        $CONDA install -y -n py${version}_conda "${RC_LABEL}"khiops-core==$(echo ${KHIOPS_REVISION} | tr -d "-") ; \
-        # remote files drivers installed in the conda environment \
-        $CONDA install -y -n py${version}_conda \
-        khiops-driver-s3==${KHIOPS_S3_DRIVER_REVISION} \
-        khiops-driver-gcs==${KHIOPS_GCS_DRIVER_REVISION} \
-        # XXX hardcoded version because the latest version is not released on conda-forge \
-        khiops-driver-azure==0.0.5; \
+        $CONDA create -y -n py${version} python=${version}; \
     done; \
     # Install Khiops from a different major version in a dedicated conda environment \
+    # for a specific test regarding compatibility test \
     # The python interpreter version of the base environment is used as no specific version is given \
     $CONDA create -y -n py3_khiops10_conda; \
-    $CONDA install -y -n py3_khiops10_conda khiops::khiops-core==10.3.1; \
+    $CONDA install -y -n py3_khiops10_conda khiops-core==10.3.2; \
     ' \
   && true
 

--- a/packaging/docker/khiopspydev/Dockerfile.rocky
+++ b/packaging/docker/khiopspydev/Dockerfile.rocky
@@ -14,8 +14,8 @@ ARG KHIOPS_REVISION
 RUN true \
   && useradd -rm -d /home/rocky -s /bin/bash -g root -u 1000 rocky \
   # Install git (for khiops-python version calculation), pandoc and pip \
-  # --allowerasing is needed to resolve package conflicts \
-  && dnf upgrade -y --allowerasing \
+  # --allowerasing --skip-broken --nobest are needed to resolve package conflicts \
+  && dnf upgrade -y --allowerasing --skip-broken --nobest \
   && dnf search pandoc \
   && dnf install --enablerepo=devel -y \
     git \
@@ -61,32 +61,25 @@ RUN true \
   && rm -rf ./khiops \
   && true
 
-# set up all the supported Python environments under conda (for the unit tests)
+# set up all the supported Python environments under Conda (for the unit tests)
 # relying on a variable containing all the versions
 ARG PYTHON_VERSIONS
 
-# Install Conda packages
-# Use `rc` label for alpha or RC khiops-core pre-releases
+# Initialize all the Conda environments
 RUN true \
   && export CONDA="/root/miniforge3/bin/conda" \
-  && if [[ $(echo ${KHIOPS_REVISION} | grep -E ".*-(a|rc)\.[0-9]+") ]]; then \
-       export RC_LABEL="conda-forge/label/rc::"; \
-     else \
-       export RC_LABEL=""; \
-     fi \
-  && /bin/bash -c 'for version in ${PYTHON_VERSIONS}; \
+  && /bin/bash -c ' \
+    # Update conda to the latest version \
+    $CONDA update -n base conda; \
+    for version in ${PYTHON_VERSIONS}; \
     do \
-        CONDA_ENVS="py${version} py${version}_conda"; \
-        for CONDA_ENV in $CONDA_ENVS; \
-        do \
-            $CONDA create -y -n $CONDA_ENV python=${version}; \
-        done; \
-        $CONDA install -y -n py${version}_conda ${RC_LABEL}khiops-core==$(echo ${KHIOPS_REVISION} | tr -d "-") ; \
+        $CONDA create -y -n py${version} python=${version}; \
     done; \
     # Install Khiops from a different major version in a dedicated conda environment \
+    # for a specific test regarding compatibility test \
     # The python interpreter version of the base environment is used as no specific version is given \
     $CONDA create -y -n py3_khiops10_conda; \
-    $CONDA install -y -n py3_khiops10_conda khiops::khiops-core==10.3.1; \
+    $CONDA install -y -n py3_khiops10_conda khiops-core==10.3.2; \
     ' \
   && true
 

--- a/packaging/docker/khiopspydev/Dockerfile.ubuntu
+++ b/packaging/docker/khiopspydev/Dockerfile.ubuntu
@@ -47,6 +47,7 @@ RUN true \
 ARG PYTHON_VERSIONS
 ARG KHIOPS_GCS_DRIVER_REVISION
 ARG KHIOPS_S3_DRIVER_REVISION
+ARG KHIOPS_AZURE_DRIVER_REVISION
 
 # Install Conda packages
 # Use `rc` label for alpha or RC khiops-core pre-releases
@@ -71,7 +72,9 @@ RUN true \
         # remote files drivers installed in the conda environment \
         $CONDA install -y -n py${version}_conda \
         khiops-driver-s3==${KHIOPS_S3_DRIVER_REVISION} \
-        khiops-driver-gcs==${KHIOPS_GCS_DRIVER_REVISION}; \
+        khiops-driver-gcs==${KHIOPS_GCS_DRIVER_REVISION} \
+        # XXX hardcoded version because the latest version is not released on conda-forge \
+        khiops-driver-azure==0.0.5; \
     done; \
     # Install Khiops from a different major version in a dedicated conda environment \
     # The python interpreter version of the base environment is used as no specific version is given \
@@ -91,9 +94,11 @@ RUN true \
     && if [ -f /etc/os-release ]; then . /etc/os-release; fi \
     && wget -O khiops-gcs.deb https://github.com/KhiopsML/khiopsdriver-gcs/releases/download/${KHIOPS_GCS_DRIVER_REVISION}/khiops-driver-gcs_${KHIOPS_GCS_DRIVER_REVISION}-1-${VERSION_CODENAME}.amd64.deb \
     && wget -O khiops-s3.deb https://github.com/KhiopsML/khiopsdriver-s3/releases/download/${KHIOPS_S3_DRIVER_REVISION}/khiops-driver-s3_${KHIOPS_S3_DRIVER_REVISION}-1-${VERSION_CODENAME}.amd64.deb \
-    && (dpkg -i --force-all khiops-gcs.deb khiops-s3.deb || true) \
+    # XXX There is a typo in the latest release tag. Until it is fixed, we need to use the hardcoded folder name
+    && wget -O khiops-azure.deb https://github.com/KhiopsML/khiopsdriver-azure/releases/download/0.0.7/khiops-driver-azure_${KHIOPS_AZURE_DRIVER_REVISION}-1-${VERSION_CODENAME}.amd64.deb \
+    && (dpkg -i --force-all khiops-gcs.deb khiops-s3.deb khiops-azure.deb || true) \
     && apt-get -f -y install \
-    && rm -f khiops-gcs.deb khiops-s3.deb \
+    && rm -f khiops-gcs.deb khiops-s3.deb khiops-azure.deb \
     && true
 
 FROM ghcr.io/khiopsml/khiops-server:${SERVER_REVISION} AS server

--- a/packaging/docker/khiopspydev/Dockerfile.ubuntu
+++ b/packaging/docker/khiopspydev/Dockerfile.ubuntu
@@ -42,44 +42,28 @@ RUN true \
   && rm -rf ./khiops \
   && true
 
-# set up all the supported Python environments under conda (for the unit tests)
+# set up all the supported Python environments under Conda (for the unit tests)
 # relying on a variable containing all the versions
 ARG PYTHON_VERSIONS
 ARG KHIOPS_GCS_DRIVER_REVISION
 ARG KHIOPS_S3_DRIVER_REVISION
 ARG KHIOPS_AZURE_DRIVER_REVISION
 
-# Install Conda packages
-# Use `rc` label for alpha or RC khiops-core pre-releases
+# Initialize all the Conda environments
 RUN true \
   && export CONDA="/root/miniforge3/bin/conda" \
-  && /bin/bash -c 'if [[ $(echo ${KHIOPS_REVISION} | grep -E ".*-(a|rc)\.[0-9]+") ]]; then \
-       export RC_LABEL="conda-forge/label/rc::"; \
-     else \
-       export RC_LABEL=""; \
-     fi; \
+  && /bin/bash -c ' \
     # Update conda to the latest version \
     $CONDA update -n base conda; \
     for version in ${PYTHON_VERSIONS}; \
     do \
-        CONDA_ENVS="py${version} py${version}_conda"; \
-        for CONDA_ENV in $CONDA_ENVS; \
-        do \
-            $CONDA create -y -n $CONDA_ENV python=${version}; \
-        done; \
-        # khiops core \
-        $CONDA install -y -n py${version}_conda "${RC_LABEL}"khiops-core==$(echo ${KHIOPS_REVISION} | tr -d "-") ; \
-        # remote files drivers installed in the conda environment \
-        $CONDA install -y -n py${version}_conda \
-        khiops-driver-s3==${KHIOPS_S3_DRIVER_REVISION} \
-        khiops-driver-gcs==${KHIOPS_GCS_DRIVER_REVISION} \
-        # XXX hardcoded version because the latest version is not released on conda-forge \
-        khiops-driver-azure==0.0.5; \
+        $CONDA create -y -n py${version} python=${version}; \
     done; \
     # Install Khiops from a different major version in a dedicated conda environment \
+    # for a specific test regarding compatibility test \
     # The python interpreter version of the base environment is used as no specific version is given \
     $CONDA create -y -n py3_khiops10_conda; \
-    $CONDA install -y -n py3_khiops10_conda khiops::khiops-core==10.3.1; \
+    $CONDA install -y -n py3_khiops10_conda khiops-core==10.3.2; \
     ' \
   && true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,12 +113,20 @@ dependencies = [
 Homepage = "https://khiops.org"
 
 [project.optional-dependencies]
+# Warning : the following dependencies are also extracted for other installation tools.
+# However Conda does not fully support PEP508 requirements specification,
+# namely the "~=" operator. Use instead version ranges.
 s3 = [
     # do not use the latest version, to avoid undesired breaking changes
     "boto3>=1.17.39,<=1.35.69",
 ]
 gcs = [
     "google-cloud-storage>=1.37.0",
+]
+azure = [
+    "azure-core>=1.39.0,<2.0.0",
+    "azure-storage-blob>=12.28.0,<13.0.0",
+    "azure-storage-file-share>=12.24.0,<13.0.0",
 ]
 
 [tool.setuptools.packages.find]

--- a/tests/test_remote_access.py
+++ b/tests/test_remote_access.py
@@ -54,6 +54,30 @@ def docker_runner_config_exists():
     )
 
 
+def azure_config_for_files_exists():
+    # Notes :
+    # `AZURE_STORAGE_CONNECTION_STRING` is a string composed of
+    # the storage account name and account key (amount other technical details)
+    # `CLOUD_FILE_URI_PREFIX` follows this pattern (for files) :
+    # <storage account name>.file.core.windows.net
+    return (
+        "AZURE_STORAGE_CONNECTION_STRING" in os.environ
+        and "CLOUD_FILE_URI_PREFIX" in os.environ
+    )
+
+
+def azure_config_for_blobs_exists():
+    # Notes :
+    # `AZURE_STORAGE_CONNECTION_STRING` is a string composed of
+    # the storage account name and account key (amount other technical details)
+    # `CLOUD_BLOB_URI_PREFIX` follows this pattern (for blobs) :
+    # <storage account name>.blob.core.windows.net
+    return (
+        "AZURE_STORAGE_CONNECTION_STRING" in os.environ
+        and "CLOUD_BLOB_URI_PREFIX" in os.environ
+    )
+
+
 class KhiopsRemoteAccessTestsContainer:
     """Container class to allow unittest.TestCase inheritance"""
 
@@ -61,12 +85,21 @@ class KhiopsRemoteAccessTestsContainer:
         """Generic class to test remote filesystems and Khiops runners"""
 
         @classmethod
-        def init_remote_bucket(cls, bucket_name=None, proto=None):
-            # create the remote root_temp_dir
-            remote_resource = fs.create_resource(
-                f"{proto}://{bucket_name}/khiops-cicd/tmp"
-            )
-            remote_resource.make_dir()
+        def init_remote_storage(cls, bucket_name_or_storage_prefix=None, proto=None):
+            # create the remote parent directories for clarity's sake
+            # even it is not required as all the remote storage implementations
+            # create the missing folders if needed
+            for remote_path in (
+                # root_temp_dir
+                f"{proto}://{bucket_name_or_storage_prefix}/khiops-cicd/tmp/",
+                # samples dir
+                f"{proto}://{bucket_name_or_storage_prefix}/khiops-cicd/samples/",
+            ):
+                remote_resource = fs.create_resource(remote_path)
+                # This action should always be idempotent if the folder already exists,
+                # for some cloud platforms it will have no effect at all;
+                # and the folder will only virtually exist when the file is written
+                remote_resource.make_dir()
 
             # copy to /samples each file
             for file in (
@@ -77,12 +110,38 @@ class KhiopsRemoteAccessTestsContainer:
                 "SpliceJunction/SpliceJunction.kdic",
             ):
                 fs.copy_from_local(
-                    f"{proto}://{bucket_name}/khiops-cicd/samples/{file}",
+                    f"{proto}://{bucket_name_or_storage_prefix}/khiops-cicd/"
+                    f"samples/{file}",
                     os.path.join(kh.get_samples_dir(), file),
                 )
+
                 # symmetric call to ensure the upload was OK
                 fs.copy_to_local(
-                    f"{proto}://{bucket_name}/khiops-cicd/samples/{file}", "/tmp/dummy"
+                    f"{proto}://{bucket_name_or_storage_prefix}/khiops-cicd/"
+                    f"samples/{file}",
+                    f"/tmp/khiops-{proto}-dummy",
+                )
+                if not os.path.isfile(f"/tmp/khiops-{proto}-dummy"):
+                    raise RuntimeError(
+                        f"/tmp/khiops-{proto}-dummy must have been created"
+                    )
+                else:
+                    os.remove(f"/tmp/khiops-{proto}-dummy")
+
+            # Ensure the "SpliceJunction" folder contains 3 files
+            if not [
+                "SpliceJunction.kdic",
+                "SpliceJunction.txt",
+                "SpliceJunctionDNA.txt",
+            ] == sorted(
+                fs.list_dir(
+                    f"{proto}://{bucket_name_or_storage_prefix}/khiops-cicd/"
+                    "samples/SpliceJunction/"
+                )
+            ):
+                raise RuntimeError(
+                    f"{proto}://{bucket_name_or_storage_prefix}/khiops-cicd/"
+                    f"samples/SpliceJunction/ should contain 3 files"
                 )
 
         def results_dir_root(self):
@@ -293,7 +352,9 @@ class KhiopsS3RemoteFileTests(KhiopsRemoteAccessTestsContainer.KhiopsRemoteAcces
             runner = kh.get_runner()
             bucket_name = os.environ["S3_BUCKET_NAME"]
 
-            cls.init_remote_bucket(bucket_name=bucket_name, proto="s3")
+            cls.init_remote_storage(
+                bucket_name_or_storage_prefix=bucket_name, proto="s3"
+            )
 
             runner.samples_dir = f"s3://{bucket_name}/khiops-cicd/samples"
             resources_directory = KhiopsTestHelper.get_resources_dir()
@@ -336,7 +397,9 @@ class KhiopsGCSRemoteFileTests(
             runner = kh.get_runner()
             bucket_name = os.environ["GCS_BUCKET_NAME"]
 
-            cls.init_remote_bucket(bucket_name=bucket_name, proto="gs")
+            cls.init_remote_storage(
+                bucket_name_or_storage_prefix=bucket_name, proto="gs"
+            )
 
             runner.samples_dir = f"gs://{bucket_name}/khiops-cicd/samples"
             resources_directory = KhiopsTestHelper.get_resources_dir()
@@ -365,6 +428,86 @@ class KhiopsGCSRemoteFileTests(
 
     def remote_access_test_case(self):
         return "GCS"
+
+
+class KhiopsAzureRemoteFileTests(
+    KhiopsRemoteAccessTestsContainer.KhiopsRemoteAccessTests
+):
+    """Integration tests with Azure Storage filesystems"""
+
+    @classmethod
+    def setUpClass(cls):
+        """Sets up remote directories in runner"""
+        if azure_config_for_files_exists():
+            runner = kh.get_runner()
+            cloud_file_uri_prefix = os.environ["CLOUD_FILE_URI_PREFIX"]
+
+            cls.init_remote_storage(
+                bucket_name_or_storage_prefix=cloud_file_uri_prefix, proto="https"
+            )
+
+            runner.samples_dir = f"https://{cloud_file_uri_prefix}/khiops-cicd/samples"
+            resources_directory = KhiopsTestHelper.get_resources_dir()
+
+            # WARNING : khiops temp files cannot be remote
+            cls._khiops_temp_dir = f"{resources_directory}/tmp/khiops-cicd"
+
+            # root_temp_dir
+            # (where the log file is saved by default when using `kh`)
+            # can be remote
+            runner.root_temp_dir = f"https://{cloud_file_uri_prefix}/khiops-cicd/tmp"
+
+    @classmethod
+    def tearDownClass(cls):
+        """Sets back the runner defaults"""
+        if azure_config_for_files_exists():
+            kh.get_runner().__init__()
+
+    def config_exists(self):
+        return azure_config_for_files_exists()
+
+    def remote_access_test_case(self):
+        return "Azure Files"
+
+
+class KhiopsAzureRemoteBlobTests(
+    KhiopsRemoteAccessTestsContainer.KhiopsRemoteAccessTests
+):
+    """Integration tests with Azure Storage filesystems : Blobs"""
+
+    @classmethod
+    def setUpClass(cls):
+        """Sets up remote directories in runner"""
+        if azure_config_for_blobs_exists():
+            runner = kh.get_runner()
+            cloud_file_uri_prefix = os.environ["CLOUD_BLOB_URI_PREFIX"]
+
+            cls.init_remote_storage(
+                bucket_name_or_storage_prefix=cloud_file_uri_prefix, proto="https"
+            )
+
+            runner.samples_dir = f"https://{cloud_file_uri_prefix}/khiops-cicd/samples"
+            resources_directory = KhiopsTestHelper.get_resources_dir()
+
+            # WARNING : khiops temp files cannot be remote
+            cls._khiops_temp_dir = f"{resources_directory}/tmp/khiops-cicd"
+
+            # root_temp_dir
+            # (where the log file is saved by default when using `kh`)
+            # can be remote
+            runner.root_temp_dir = f"https://{cloud_file_uri_prefix}/khiops-cicd/tmp"
+
+    @classmethod
+    def tearDownClass(cls):
+        """Sets back the runner defaults"""
+        if azure_config_for_blobs_exists():
+            kh.get_runner().__init__()
+
+    def config_exists(self):
+        return azure_config_for_blobs_exists()
+
+    def remote_access_test_case(self):
+        return "Azure Blobs"
 
 
 class KhiopsDockerRunnerTests(KhiopsRemoteAccessTestsContainer.KhiopsRemoteAccessTests):

--- a/tests/test_remote_access.py
+++ b/tests/test_remote_access.py
@@ -159,10 +159,6 @@ class KhiopsRemoteAccessTestsContainer:
             """To be overridden by descendants"""
             return ""
 
-        def should_skip_in_a_conda_env(self):
-            """To be overridden by descendants"""
-            return True
-
         def print_test_title(self):
             print(f"\n   Remote System: {self.remote_access_test_case()}")
 
@@ -201,11 +197,6 @@ class KhiopsRemoteAccessTestsContainer:
             KhiopsTestHelper.skip_expensive_test(self)
 
             self.skip_if_no_config()
-            if self.is_in_a_conda_env() and self.should_skip_in_a_conda_env():
-                self.skipTest(
-                    f"Remote test case {self.remote_access_test_case()} "
-                    "in a conda environment is currently skipped"
-                )
             self.print_test_title()
 
             # Save the runner that can be modified by the test
@@ -373,11 +364,6 @@ class KhiopsS3RemoteFileTests(KhiopsRemoteAccessTestsContainer.KhiopsRemoteAcces
         if s3_config_exists():
             kh.get_runner().__init__()
 
-    def should_skip_in_a_conda_env(self):
-        # The S3 driver is now released for conda too.
-        # No need to skip the tests any longer in a conda environment
-        return False
-
     def config_exists(self):
         return s3_config_exists()
 
@@ -417,11 +403,6 @@ class KhiopsGCSRemoteFileTests(
         """Sets back the runner defaults"""
         if gcs_config_exists():
             kh.get_runner().__init__()
-
-    def should_skip_in_a_conda_env(self):
-        # The GCS driver is now released for conda too.
-        # No need to skip the tests any longer in a conda environment
-        return False
 
     def config_exists(self):
         return gcs_config_exists()
@@ -604,11 +585,6 @@ class KhiopsDockerRunnerTests(KhiopsRemoteAccessTestsContainer.KhiopsRemoteAcces
 
     def config_exists(self):
         return docker_runner_config_exists()
-
-    def should_skip_in_a_conda_env(self):
-        # Tests using a docker runner should never be skipped
-        # even in a conda environment
-        return False
 
     def remote_access_test_case(self):
         return "KhiopsDockerRunner"


### PR DESCRIPTION
- Among all the Azure storages, Khiops supports only (via its specific driver) "Files" and "Blobs" (Binary Large Objects)
 - The only supported authentication method is currently the `AZURE_STORAGE_CONNECTION_STRING` embedding the account name and account key

Completes #244 and fixes #576

---

### TODO Before Asking for a Review
- [x] Rebase your branch to the latest version of `main` (or `main-v10`)
- [x] Make sure all CI workflows are green
- [x] When adding a public feature/fix: Update the `Unreleased` section of `CHANGELOG.md` (no date)
- [x] Self-Review: Review "Files Changed" tab and fix any problems you find
- API Docs (only if there are changes in docstrings, rst files or samples):
  - [ ] Check the docs build **without** warning: see the log of the API Docs workflow
  - [ ] Check that your changes render well in HTML: download the API Docs artifact and open `index.html`
  - If there are any problems it is faster to iterate by [building locally the API Docs](../blob/main/doc/README.md#build-the-documentation)
