### PR TITLE
Make local path filesystem helper functions private

### DIFF
--- a/khiops/core/api.py
+++ b/khiops/core/api.py
@@ -864,7 +864,7 @@ def train_predictor(
 
     # Return the paths of the JSON report and modelling dictionary file
     if target_variable != "":
-        current_dir = fs.parent_path(analysis_report_file_path)
+        current_dir = fs.get_parent_path(analysis_report_file_path)
         report_file_name, _ = os.path.splitext(
             os.path.basename(analysis_report_file_path)
         )
@@ -1320,7 +1320,7 @@ def train_recoder(
     _run_task("train_recoder", task_args)
 
     # Return the paths of the JSON report and modelling dictionary file
-    current_dir = fs.parent_path(analysis_report_file_path)
+    current_dir = fs.get_parent_path(analysis_report_file_path)
     report_file_name, _ = os.path.splitext(os.path.basename(analysis_report_file_path))
 
     modeling_dictionary_file_path = fs.get_child_path(

--- a/khiops/core/coclustering_results.py
+++ b/khiops/core/coclustering_results.py
@@ -784,7 +784,7 @@ class CoclusteringDimension:
         Contains the dimensions of the variables involved in the
         instances x variables coclustering model.
         This model includes two dimensions: one for instances and one for variable
-        parts (`isVarPart` set to ``True`` for this dimension).
+        parts (``isVarPart`` set to ``True`` for this dimension).
     clusters : list of `CoclusteringCluster`
         Clusters of this dimension's hierarchy. Note that includes intermediary
         clusters.

--- a/khiops/core/internals/filesystems.py
+++ b/khiops/core/internals/filesystems.py
@@ -52,6 +52,81 @@ except ImportError as import_error:
 
 # pylint: enable=invalid-name
 
+#######################
+## Private functions ##
+#######################
+
+
+def _parent_path(path):
+    r"""Returns the parent of the specified path
+
+    Notes
+    -----
+    This function always returns a posix path ("/" as separator). For example for the
+    windows path::
+
+        C:\Program Files\khiops
+
+    this method returns::
+
+        C:/Program Files
+    """
+    return Path(path).parent.as_posix()
+
+
+def _parent_uri_info(uri_info):
+    """Creates the parent for the input URI info
+
+    Parameters
+    ----------
+    uri_info : `urllib.parse.ParseResult`
+        URI info structure (output of `urllib.parse.urlparse`)
+
+    Returns
+    -------
+    `urllib.parse.ParseResult`
+        URI info structure for the parent URI
+
+    """
+    return uri_info._replace(path=_parent_path(uri_info.path))
+
+
+def _child_path(path, child_name):
+    r"""Creates a path with a child appended
+
+    Notes
+    -----
+    This function always returns a posix path ("/" as separator). For example for the
+    windows path and child name::
+
+        parent: C:\Program Files
+        child:  khiops
+
+    this method returns::
+        C:/Program Files/khiops
+    """
+    return Path(path).joinpath(child_name).as_posix()
+
+
+def _child_uri_info(uri_info, child_name):
+    r"""Creates a URI info with a path with child appended
+
+    Parameters
+    ----------
+    uri_info : `urllib.parse.ParseResult`
+        URI info structure (output of `urllib.parse.urlparse`)
+
+    child_name : str
+        Name of the new childe node
+
+    Returns
+    -------
+    `urllib.parse.ParseResult`
+        URI info structure for the child URI
+    """
+    return uri_info._replace(path=_child_path(uri_info.path, child_name))
+
+
 ######################
 ## Helper Functions ##
 ######################
@@ -136,76 +211,6 @@ def create_resource(uri_or_path):
     # No scheme separator `://` found: Build a local resource
     else:
         return LocalFilesystemResource(uri_or_path)
-
-
-def parent_path(path):
-    r"""Returns the parent of the specified path
-
-    Notes
-    -----
-    This function always return a posix path ("/" as separator). For example for the
-    windows path::
-
-        C:\Program Files\khiops
-
-    this method returns::
-
-        C:/Program Files
-    """
-    return Path(path).parent.as_posix()
-
-
-def parent_uri_info(uri_info):
-    """Creates the parent for the input URI info
-
-    Parameters
-    ----------
-    uri_info : `urllib.parse.ParseResult`
-        URI info structure (output of `urllib.parse.urlparse`)
-
-    Returns
-    -------
-    `urllib.parse.ParseResult`
-        URI info structure for the parent URI
-
-    """
-    return uri_info._replace(path=parent_path(uri_info.path))
-
-
-def child_path(path, child_name):
-    r"""Creates a path with a child appended
-
-    Notes
-    -----
-    This function always return a posix path ("/" as separator). For example for the
-    windows path and child name::
-
-        parent: C:\Program Files
-        child:  khiops
-
-    this method returns::
-        C:/Program Files/khiops
-    """
-    return Path(path).joinpath(child_name).as_posix()
-
-
-def child_uri_info(uri_info, child_name):
-    r"""Creates a URI info with a path with child appended
-
-    Parameters
-    ----------
-    uri_info : `urllib.parse.ParseResult`
-        URI info structure (output of `urllib.parse.urlparse`)
-
-    child_name : str
-        Name of the new childe node
-
-    Returns
-    -------
-    `urllib.parse.ParseResult`
-        URI info structure for the child URI
-    """
-    return uri_info._replace(path=child_path(uri_info.path, child_name))
 
 
 ##############
@@ -373,7 +378,7 @@ def get_child_path(uri_or_path, child_name):
 
 
 def get_parent_path(uri_or_path):
-    """Returns the specified parent path of this URI
+    """Returns the parent path of this URI
 
     Parameters
     ----------
@@ -523,7 +528,7 @@ class LocalFilesystemResource(FilesystemResource):
         return create_resource(os.path.join(self.path, file_name))
 
     def create_parent(self):
-        return create_resource(parent_path(self.path))
+        return create_resource(_parent_path(self.path))
 
 
 class GoogleCloudStorageResource(FilesystemResource):
@@ -592,10 +597,10 @@ class GoogleCloudStorageResource(FilesystemResource):
         )
 
     def create_child(self, file_name):
-        return create_resource(child_uri_info(self.uri_info, file_name).geturl())
+        return create_resource(_child_uri_info(self.uri_info, file_name).geturl())
 
     def create_parent(self):
-        return create_resource(parent_uri_info(self.uri_info).geturl())
+        return create_resource(_parent_uri_info(self.uri_info).geturl())
 
 
 # Avoid pylint complaining on dynamic class returned by boto3 API
@@ -752,10 +757,10 @@ class AmazonS3Resource(FilesystemResource):
         )
 
     def create_child(self, file_name):
-        return create_resource(child_uri_info(self.uri_info, file_name).geturl())
+        return create_resource(_child_uri_info(self.uri_info, file_name).geturl())
 
     def create_parent(self):
-        return create_resource(parent_uri_info(self.uri_info).geturl())
+        return create_resource(_parent_uri_info(self.uri_info).geturl())
 
 
 # pylint: enable=no-member
@@ -806,10 +811,10 @@ class AzureStorageResourceMixin:
         )
 
     def create_child(self, file_name):
-        return create_resource(child_uri_info(self.uri_info, file_name).geturl())
+        return create_resource(_child_uri_info(self.uri_info, file_name).geturl())
 
     def create_parent(self, file_name):  # pylint: disable=unused-argument
-        return create_resource(parent_uri_info(self.uri_info).geturl())
+        return create_resource(_parent_uri_info(self.uri_info).geturl())
 
     def _uri_parts(self):
         return [part for part in self.uri_info.path.split("/") if len(part) > 0]

--- a/khiops/core/internals/filesystems.py
+++ b/khiops/core/internals/filesystems.py
@@ -833,7 +833,7 @@ class AzureStorageFileResource(AzureStorageResourceMixin, FilesystemResource):
 
     For shared Files, the URI pattern of a resource is the following :
     https://<storage-account-name>.file.core.windows.net/<share name>/...
-                                                <0 to n folder name(s)>/<file name>
+    <0 to n folder name(s)>/<file name>.
     The first name after the netloc is the "share name" not a simple "folder name".
 
     By default, this resource reads the configuration from standard location
@@ -918,8 +918,9 @@ class AzureStorageFileResource(AzureStorageResourceMixin, FilesystemResource):
 
     def list_dir(self):
         """List the files (not the directories) of the current directory
-        Notes:
-            This is not a recursive listing operation
+
+        .. note::
+            This is not a recursive listing operation.
         """
 
         return [
@@ -962,7 +963,7 @@ class AzureStorageBlobResource(AzureStorageResourceMixin, FilesystemResource):
 
     For blobs, the URI pattern of a resource is the following:
     https://<storage-account-name>.blob.core.windows.net/<container name>/...
-                                        <0 to n virtual folder name(s)>/<blob name>
+    <0 to n virtual folder name(s)>/<blob name>.
     The "virtual folder names" are part of the blob name but can help simulate
     a folder hierarchy.
     The first name after the netloc is the "container name" not a simple


### PR DESCRIPTION
Also update the Core api code accordingly: use the public, portable for remote paths, filesystem functions.

closes #570

---

### TODO Before Asking for a Review
- [x] Rebase your branch to the latest version of `main` (or `main-v10`)
- [x] Make sure all CI workflows are green
- [ ] When adding a public feature/fix: Update the `Unreleased` section of `CHANGELOG.md` (no date)
- [x] Self-Review: Review "Files Changed" tab and fix any problems you find
- API Docs (only if there are changes in docstrings, rst files or samples):
  - [ ] Check the docs build **without** warning: see the log of the API Docs workflow
  - [ ] Check that your changes render well in HTML: download the API Docs artifact and open `index.html`
  - If there are any problems it is faster to iterate by [building locally the API Docs](../blob/main/doc/README.md#build-the-documentation)
