### PR TITLE
Document external data table paths in various contexts

### DIFF
--- a/doc/multi_table_primer.rst
+++ b/doc/multi_table_primer.rst
@@ -208,6 +208,28 @@ Types of secondary tables include:
     than the number of addresses so it may make sense to load it entirely in memory for efficiency
     reasons.
 
+  .. note:: In `.khiops.core.api.evaluate_predictor`, the initial name of the
+      external table must be used, which is the same as the one used for
+      training the predictor. 
+      For example:
+
+      .. code-block:: c
+
+         additional_data_tables: {
+             "/City": "/path/to/Cities.csv"
+         }
+
+  .. note:: In `.khiops.core.api.deploy_model`, model dictionary data paths must be used for
+       external tables. For example, when deploying a classification or a regression
+       model:
+
+       .. code-block:: c
+
+          additional_data_tables: {
+              "/SNB_City": "/path/to/Cities.csv"
+          }
+
+
 Note that besides the root table names the components of a data path are **table variable names**
 and not *table names*. For further details about the multi-table capabilities of Khiops refer to the
 documentation at `the Khiops site <https://khiops.org/setup/KhiopsGuide.pdf>`_.

--- a/khiops/core/api.py
+++ b/khiops/core/api.py
@@ -712,6 +712,11 @@ def train_predictor(
 ):
     r"""Trains a model from a data table
 
+    .. note::
+         For all input dictionaries, this function creates model dictionaries whose
+         names are prefixed with ``SNB_``. For regression models, additional
+         dictionaries are created and their names are prefixed with ``Baseline_``.
+
     Parameters
     ----------
     dictionary_file_path_or_domain : str or `.DictionaryDomain`
@@ -1069,7 +1074,9 @@ def evaluate_predictor(
         A dictionary containing the data paths and file paths for a multi-table
         dictionary file. For more details see :doc:`/multi_table_primer`.
 
-        .. note:: Use the initial dictionary name in the data paths.
+        .. note::
+             For external tables, use the initial dictionary name in the data paths,
+             which is the same as the one used for training the predictor.
 
     main_target_value : str, default ""
         If this target value is specified then it guarantees the calculation of lift
@@ -1164,6 +1171,10 @@ def train_recoder(
 
     The output files of this process contain a dictionary file (``.kdic``) that can be
     used to recode databases with the `deploy_model` function.
+
+    .. note::
+      For all input dictionaries, this function creates model dictionaries whose names
+      are prefixed with ``R_``.
 
     Parameters
     ----------
@@ -1400,6 +1411,9 @@ def deploy_model(
     additional_data_tables : dict, optional
         A dictionary containing the data paths and file paths for a multi-table
         dictionary file. For more details see :doc:`/multi_table_primer`.
+
+        .. note:: Use model dictionary data paths for external tables.
+
     output_header_line : bool, default ``True``
         If ``True`` writes a header line with the column names in the output table.
     output_field_separator : str, default "\\t"


### PR DESCRIPTION
- In `train_predictor`, `SNB_` or `Baseline_`-prefixed model dictionaries are generated. Similarly, in `train_recoder`, `R_`-prefixed model dictionaries are generated.

- In `deploy_model`, these prefixed dictionaries must be used, even for external tables.

- However, in `evaluate_predictor`, the original names must be used for external tables, in order to support evaluating several predictors.


_Put your message here_

---

### TODO Before Asking for a Review
- [x] Rebase your branch to the latest version of `main` (or `main-v10`)
- [x] Make sure all CI workflows are green
- [ ] When adding a public feature/fix: Update the `Unreleased` section of `CHANGELOG.md` (no date)
- [x] Self-Review: Review "Files Changed" tab and fix any problems you find
- API Docs (only if there are changes in docstrings, rst files or samples):
  - [ ] Check the docs build **without** warning: see the log of the API Docs workflow
  - [ ] Check that your changes render well in HTML: download the API Docs artifact and open `index.html`
  - If there are any problems it is faster to iterate by [building locally the API Docs](../blob/main/doc/README.md#build-the-documentation)
