### PR TITLE
Fix the versions check in the Pip workflow

### DIFF
--- a/.github/workflows/pip.yml
+++ b/.github/workflows/pip.yml
@@ -217,9 +217,10 @@ jobs:
           if [[ "${{ matrix.env.use-virtualenv }}" == "true" ]]; then
             deactivate
           fi
-          echo "${{ github.ref_name }}" | tr -d '-' | rev | sed -E 's/\.([^0-9].*)/\1/' | rev | \
-            grep -wq "$PACKAGE_VERSION"
-          if [[ $? -ne 0 ]]
+          # Remove any '.' or '-' from the versions to be able to compare them canonically
+          canonic_tag_name=$(echo "${{ github.ref_name }}" | perl -pe "s/[\.-]//g")
+          canonic_package_version=$(echo $PACKAGE_VERSION  | perl -pe "s/[\.-]//g")            
+          if [[ "$canonic_tag_name" != "$canonic_package_version" ]]
           then
             echo "::error::Python package version $PACKAGE_VERSION does not match Git tag ${{ github.ref_name }}"
             false


### PR DESCRIPTION
- as the 'rev' is not installed by default on Windows 2025 runner (allegedly in 'linux-utils'), it seems simpler to change the check

---

### TODO Before Asking for a Review
- [ ] Rebase your branch to the latest version of `main` (or `main-v10`)
- [ ] Make sure all CI workflows are green
- [ ] When adding a public feature/fix: Update the `Unreleased` section of `CHANGELOG.md` (no date)
- [ ] Self-Review: Review "Files Changed" tab and fix any problems you find
- API Docs (only if there are changes in docstrings, rst files or samples):
  - [ ] Check the docs build **without** warning: see the log of the API Docs workflow
  - [ ] Check that your changes render well in HTML: download the API Docs artifact and open `index.html`
  - If there are any problems it is faster to iterate by [building locally the API Docs](../blob/main/doc/README.md#build-the-documentation)
