### PR TITLE
Give the user a hint on Windows when khiops_env.cmd fails

### DIFF
--- a/khiops/core/internals/runner.py
+++ b/khiops/core/internals/runner.py
@@ -1019,10 +1019,20 @@ class KhiopsLocalRunner(KhiopsRunner):
         ) as khiops_env_process:
             stdout, stderr = khiops_env_process.communicate()
             if khiops_env_process.returncode != 0:
-                raise KhiopsEnvironmentError(
+                error_message = (
                     "Error initializing the environment for Khiops from the "
                     f"{khiops_env_path} script. Contents of stderr:\n{stderr}"
                 )
+                if platform.system() == "Windows":
+                    # Give the user a hint to resolve the issue on Windows
+                    error_message += (
+                        "\nThe issue may be caused by Khiops being installed "
+                        "in a location restricted by your organization's IT "
+                        "security policy. In this case, try re-installing "
+                        "the Khiops Python Library in a recommended directory "
+                        "or run your IDE or terminal as an administrator."
+                    )
+                raise KhiopsEnvironmentError(error_message)
             for line in stdout.split("\n"):
                 tokens = line.rstrip().split(maxsplit=1)
                 if len(tokens) == 2:


### PR DESCRIPTION
khiops_env.cmd failure on Windows is usually caused by security policies preventing executables from running if they are located outside approved locations

Fixes #613 

---

### TODO Before Asking for a Review
- [x] Rebase your branch to the latest version of `main` (or `main-v10`)
- [x] Make sure all CI workflows are green
- [ ] When adding a public feature/fix: Update the `Unreleased` section of `CHANGELOG.md` (no date)
- [x] Self-Review: Review "Files Changed" tab and fix any problems you find
- API Docs (only if there are changes in docstrings, rst files or samples):
  - [ ] Check the docs build **without** warning: see the log of the API Docs workflow
  - [ ] Check that your changes render well in HTML: download the API Docs artifact and open `index.html`
  - If there are any problems it is faster to iterate by [building locally the API Docs](../blob/main/doc/README.md#build-the-documentation)
