### PR TITLE
Fix a RuntimeException error when automatically correcting deprecated data paths (pre v11) in task args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@
   - Example: 10.2.1.4 is the 5th version that supports khiops 10.2.1.
 - Internals: Changes in *Internals* sections are unlikely to be of interest for data scientists.
 
+## Unreleased
+
+### Fixed
+- (`core`) Fix a RuntimeException error when automatically correcting deprecated data paths in task args
+
 ## 11.0.1.0 - 2026-07-02
 
 ### Added

--- a/khiops/core/api.py
+++ b/khiops/core/api.py
@@ -175,7 +175,7 @@ def _preprocess_arguments(args):
 
     .. note:: This function *mutates* the input `args` dictionary.
     """
-    # Execute the preprocess of common task arguments
+    # Execute the preprocessing of common task arguments
     task_is_called_with_domain = _preprocess_task_arguments(args)
 
     # Create a command line options object
@@ -222,6 +222,9 @@ def _deprecate_legacy_data_path(data_path_task_arg_name, task_args):
     """Detect and replace legacy data path with the current syntax
 
     .. note:: The function mutates task_args.
+    .. note:: A similar logic is repeated in `DictionaryDomain`
+              but cannot be factored out in a simple way
+              because no `DictionaryDomain` object is built here
     """
     if (
         data_path_task_arg_name in task_args
@@ -233,7 +236,9 @@ def _deprecate_legacy_data_path(data_path_task_arg_name, task_args):
         else:
             current_dictionary_name = task_args["train_dictionary_name"]
 
-        for kdic_path in task_args[data_path_task_arg_name].keys():
+        # Iterate through the keys of a clone to avoid any error
+        # while modifying the dict in-place
+        for kdic_path in task_args[data_path_task_arg_name].copy().keys():
             if isinstance(kdic_path, str):
                 deprecated_data_path_separator = "`"
                 data_path_separator = "/"
@@ -255,7 +260,7 @@ def _deprecate_legacy_data_path(data_path_task_arg_name, task_args):
                 source_dictionary_name = kdic_path_parts[0]
                 if source_dictionary_name == current_dictionary_name:
                     # Escape any "/" char in the path parts except for the
-                    # current dictionary, which is is skipped from the new path
+                    # current dictionary, which is skipped from the new path
                     new_kdic_path_parts = []
                     for kdic_path_part in kdic_path_parts[1:]:
                         new_kdic_path_parts.append(

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -25,6 +25,7 @@ import khiops
 import khiops.core as kh
 import khiops.core.internals.filesystems as fs
 from khiops.core import KhiopsRuntimeError
+from khiops.core.api import _deprecate_legacy_data_path
 from khiops.core.internals.io import KhiopsOutputWriter
 from khiops.core.internals.runner import KhiopsLocalRunner, KhiopsRunner
 from khiops.core.internals.scenario import ConfigurableKhiopsScenario
@@ -2568,6 +2569,25 @@ class KhiopsCoreServicesTests(unittest.TestCase):
                         dictionary_from_legacy_data_path,
                         domain.get_dictionary_at_data_path(data_path),
                     )
+
+    def test_deprecated_legacy_data_path_in_task_args(self):
+        """Tests the automatic correction of deprecated data paths in task args"""
+        data_path_task_arg_name = "additional_data_tables"
+        task_args = {
+            "dictionary_name": "SpliceJunction",
+            "additional_data_tables": {"SpliceJunction`DNA": "SpliceJunctionDNA.txt"},
+        }
+        _deprecate_legacy_data_path(data_path_task_arg_name, task_args)
+        self.assertNotIn(
+            "SpliceJunction`DNA",
+            task_args["additional_data_tables"],
+            "Deprecated data path should have been removed",
+        )
+        self.assertEqual(
+            {"DNA": "SpliceJunctionDNA.txt"},
+            task_args["additional_data_tables"],
+            "Deprecated data path should have been corrected",
+        )
 
 
 class ScenarioWriterRunner(KhiopsRunner):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2577,7 +2577,21 @@ class KhiopsCoreServicesTests(unittest.TestCase):
             "dictionary_name": "SpliceJunction",
             "additional_data_tables": {"SpliceJunction`DNA": "SpliceJunctionDNA.txt"},
         }
-        _deprecate_legacy_data_path(data_path_task_arg_name, task_args)
+        with warnings.catch_warnings(record=True) as warning_list:
+            _deprecate_legacy_data_path(data_path_task_arg_name, task_args)
+        self.assertTrue(len(warning_list) > 0)
+        deprecation_warning_found = False
+        for warning in warning_list:
+            warning_message = warning.message
+            if (
+                issubclass(warning.category, UserWarning)
+                and len(warning_message.args) == 1
+                and "'`'-based dictionary data path" in warning_message.args[0]
+                and "deprecated" in warning_message.args[0]
+            ):
+                deprecation_warning_found = True
+                break
+        self.assertTrue(deprecation_warning_found)
         self.assertNotIn(
             "SpliceJunction`DNA",
             task_args["additional_data_tables"],


### PR DESCRIPTION
Fixes #610 

---

### TODO Before Asking for a Review
- [x] Rebase your branch to the latest version of `main` (or `main-v10`)
- [x] Make sure all CI workflows are green
- [x] When adding a public feature/fix: Update the `Unreleased` section of `CHANGELOG.md` (no date)
- [x] Self-Review: Review "Files Changed" tab and fix any problems you find
- API Docs (only if there are changes in docstrings, rst files or samples):
  - [ ] Check the docs build **without** warning: see the log of the API Docs workflow
  - [ ] Check that your changes render well in HTML: download the API Docs artifact and open `index.html`
  - If there are any problems it is faster to iterate by [building locally the API Docs](../blob/main/doc/README.md#build-the-documentation)
