### PR TITLE
Suppress a warning when 'uv' is used instead of 'pip'

### DIFF
--- a/khiops/core/internals/runner.py
+++ b/khiops/core/internals/runner.py
@@ -244,12 +244,12 @@ def _infer_khiops_installation_method(trace=False):
        it was not activated previously nor during the execution
        and thus the CONDA_PREFIX environment variable is undefined
        and the path to the `bin` directory inside the conda environment is not in PATH
-    - 'pip' environment containing binaries, shared libraries and the Python libraries
-      can either be:
-      - system-wide (strongly discouraged)
+    - 'pip-uv' environment containing binaries, shared libraries and
+      the Python libraries can either be:
+      - system-wide (strongly discouraged) -- applicable for 'pip' only
       - or in the Python folder inside the home directory of the user
-        (a.k.a. "User site")
-      - or in a classical virtual environment (highly encouraged)
+        (a.k.a. "User site") -- applicable for 'pip' only
+      - or in a classical virtual environment (highly encouraged) -- for 'pip' and 'uv'
 
     """
     # We are in a Conda environment if
@@ -279,10 +279,10 @@ def _infer_khiops_installation_method(trace=False):
         ):
             installation_method = "conda-based"
         else:
-            installation_method = "pip"
+            installation_method = "pip-uv"
     if trace:
         print(f"Installation method: '{installation_method}'")
-    assert installation_method in ("conda", "conda-based", "pip")
+    assert installation_method in ("conda", "conda-based", "pip-uv")
     return installation_method
 
 
@@ -301,7 +301,7 @@ def _get_current_library_installer():
     Returns
     -------
     str
-        installer name among : 'pip', 'conda' or 'unknown'
+        installer name among : 'pip', 'uv', 'conda' or 'unknown'
     """
 
     try:
@@ -323,12 +323,12 @@ def _get_current_library_installer():
         warnings.warn(
             "The python library metadata exists ('khiops-*.dist-info') "
             "but seems corrupted as no INSTALLER file can be found. "
-            "Please re-install using the same tool ('conda' or 'pip').",
+            "Please re-install using the same tool ('conda', 'pip' or 'uv').",
             stacklevel=3,
         )
         return "unknown"
     except PackageNotFoundError:
-        # The python library is not installed via standard tools like conda, pip...
+        # The python library is not installed via standard tools like conda, pip, uv
         return "unknown"
 
 
@@ -968,7 +968,7 @@ class KhiopsLocalRunner(KhiopsRunner):
             # In an activated conda environment, khiops_env is in PATH.
             case "conda":
                 khiops_env_path = self._infer_khiops_env_from_path(installation_method)
-            case "pip":
+            case "pip-uv":
                 # Ensure the binary dependency is still installed.
                 try:
                     distribution("khiops-core")
@@ -978,12 +978,12 @@ class KhiopsLocalRunner(KhiopsRunner):
                         "Re-install the Khiops Python library to automatically install "
                         "Khiops. Go to https://khiops.org for more information.\n"
                     ) from exc
-                # On Windows, determine the Scripts directory where pip placed
+                # On Windows, determine the Scripts directory where pip or uv placed
                 # khiops_env.cmd.
                 # If this library is installed under the user site-packages
                 # directory, khiops-core (and its khiops_env.cmd) was also installed
                 # there with `pip install --user`, so use the user Scripts directory.
-                # Otherwise use the standard Scripts directory (venv or system-wide
+                # Otherwise, use the standard Scripts directory (venv or system-wide
                 # install). This avoids an ambiguous search and mirrors how pip
                 # resolves scripts.
                 if platform.system() == "Windows":
@@ -1000,7 +1000,7 @@ class KhiopsLocalRunner(KhiopsRunner):
                             "Make sure you have installed Khiops properly. "
                             "Go to https://khiops.org for more information."
                         )
-                # On UNIX, pip places khiops_env in the bin directory,
+                # On UNIX, pip or uv places khiops_env in the bin directory,
                 # which is in PATH.
                 else:
                     khiops_env_path = self._infer_khiops_env_from_path(
@@ -1053,7 +1053,10 @@ class KhiopsLocalRunner(KhiopsRunner):
                 # "KHIOPS_MPI_DLL_PATH" (containing the Intel MPI Library)
                 # must be added to "PATH" otherwise Khiops wouldn't find it
                 # and fail immediately
-                elif installation_method == "pip" and var_name == "KHIOPS_MPI_DLL_PATH":
+                elif (
+                    installation_method == "pip-uv"
+                    and var_name == "KHIOPS_MPI_DLL_PATH"
+                ):
                     os.environ["PATH"] = os.pathsep.join(
                         [var_value, os.environ.get("PATH")]
                     )
@@ -1192,7 +1195,7 @@ class KhiopsLocalRunner(KhiopsRunner):
                     "Go to https://khiops.org for instructions.\n"
                 )
                 error_list.append(error)
-        # 'pip', 'conda-based' or borderline installations
+        # 'pip-uv', 'conda-based' or borderline installations
         else:
 
             # ensure a known installer was used otherwise unexpected issues can occur
@@ -1203,19 +1206,19 @@ class KhiopsLocalRunner(KhiopsRunner):
             if caught_warnings is not None:
                 # caught_warnings contains a list of WarningMessage
                 warning_list.extend([w.message for w in caught_warnings])
-            if current_library_installer not in ("conda", "pip"):
+            if current_library_installer not in ("conda", "pip", "uv"):
                 warning = (
                     "Khiops Python library "
-                    "was not installed with 'conda' or 'pip' "
+                    "was not installed with 'conda', 'pip' or 'uv' "
                     f"but with '{current_library_installer}' installer. "
                     "This will probably lead to unexpected errors. "
                     "Go to https://khiops.org for instructions to re-install it.\n"
                 )
                 warning_list.append(warning)
 
-            # we consider only the 'pip' and 'conda-based' installations here
+            # we consider only the 'pip-uv' and 'conda-based' installations here
             # - 'conda-based' installation (similar to a non-activated virtual env)
-            # - 'pip' installation under a virtual env
+            # - 'pip' or 'uv' installation under a virtual env
             # - User site 'pip' installation (without virtual env)
             # - system-wide 'pip' installation (without virtual env)...
             # (an empty string means a borderline installation was found,
@@ -1242,7 +1245,7 @@ class KhiopsLocalRunner(KhiopsRunner):
                         and
                         # Under Windows, there are two cases :
                         # for conda-based installations python is inside 'base_dir'
-                        # for 'pip' installations (within a virtual env)
+                        # for 'pip-uv' installations (within a virtual env)
                         # python is inside 'base_dir'/Scripts
                         base_dir_path
                         not in (


### PR DESCRIPTION
- take into account the 'uv' string in the INSTALLER meta-file
- the 'pip' installation method becomes 'pip-uv' as they are quite similar

Fixes #602 

The only surprising detail for the user would be seeing 'pip-uv' in the status
```
khiops local installation settings
version             : 11.0.1
...
install type        : pip-uv
```

---

### TODO Before Asking for a Review
- [x] Rebase your branch to the latest version of `main` (or `main-v10`)
- [x] Make sure all CI workflows are green
- [ ] When adding a public feature/fix: Update the `Unreleased` section of `CHANGELOG.md` (no date)
- [x] Self-Review: Review "Files Changed" tab and fix any problems you find
- API Docs (only if there are changes in docstrings, rst files or samples):
  - [ ] Check the docs build **without** warning: see the log of the API Docs workflow
  - [ ] Check that your changes render well in HTML: download the API Docs artifact and open `index.html`
  - If there are any problems it is faster to iterate by [building locally the API Docs](../blob/main/doc/README.md#build-the-documentation)
