### PR TITLE
Add `max_cores` to the sklearn `fit` methods in estimators to limit the number of CPU cores allocated to the training

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@
   - Example: 10.2.1.4 is the 5th version that supports khiops 10.2.1.
 - Internals: Changes in *Internals* sections are unlikely to be of interest for data scientists.
 
+## Unreleased
+
+### Changed
+- (`sklearn`) The `fit` methods in estimators accept `max_cores` to limit the number of CPU cores allocated to the training  
+
 ## 11.0.1.0 - 2026-07-02
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@
 ## Unreleased
 
 ### Changed
-- (`sklearn`) The `fit` methods in estimators accept `max_cores` to limit the number of CPU cores allocated to the training  
+- (`sklearn`) The `fit` methods in estimators accept `max_cores` to limit the number of CPU cores allocated to the training
+- (General) When `max_cores` is set, use also its value to limit the number of pre-allocated CPU cores (instead of using all the available ones).
 
 ## 11.0.1.0 - 2026-07-02
 

--- a/khiops/core/api.py
+++ b/khiops/core/api.py
@@ -193,7 +193,12 @@ def _preprocess_arguments(args):
         if arg == "max_cores":
             max_cores = args[arg]
             if max_cores is not None:
+                # This `max_cores` system setting will be used in the khiops scenario
+                # to limit the CPU cores to use for the training
                 system_settings.max_cores = int(max_cores)
+                # An additional environment variable (local to this specific run)
+                # MUST also be set to avoid allocating all the available CPU cores.
+                # Thus, allocated CPU cores = max number of CPU cores used
         elif arg == "memory_limit_mb":
             memory_limit_mb = args[arg]
             if memory_limit_mb is not None:

--- a/khiops/core/internals/runner.py
+++ b/khiops/core/internals/runner.py
@@ -332,11 +332,18 @@ def _get_current_library_installer():
         return "unknown"
 
 
-def _build_khiops_process_environment():
+def _build_khiops_process_environment(system_settings=None):
     """Build a specific environment used for the execution of khiops in a process
 
     This environment can be modified freely without interfering
     with the global one.
+
+    Parameters
+    ----------
+
+    system_settings: `SystemSettings`
+            Set of settings that must be taken into account
+            for this specific run
     """
     khiops_env = os.environ.copy()
 
@@ -344,6 +351,11 @@ def _build_khiops_process_environment():
     # (using KHIOPS_MPI_HOME if it exists)
     if "HOME" not in khiops_env:
         khiops_env["HOME"] = khiops_env.get("KHIOPS_MPI_HOME", "")
+    if system_settings is not None and system_settings.max_cores is not None:
+        # An additional environment variable (local to this specific run)
+        # must also be set to avoid allocating all the available CPU cores.
+        # Thus, allocated CPU cores = max number of CPU cores used
+        khiops_env["KHIOPS_PROC_NUMBER"] = system_settings.max_cores
     return khiops_env
 
 
@@ -690,6 +702,7 @@ class KhiopsRunner(ABC):
                 scenario_path,
                 command_line_options,
                 trace,
+                system_settings,
             )
             # pylint: enable=assignment-from-no-return
         # Catch an OS level error if any
@@ -895,6 +908,7 @@ class KhiopsRunner(ABC):
         scenario_path,
         command_line_options,
         trace,
+        system_settings,
     ):
         """Abstract run method to be implemented in child classes
 
@@ -1449,7 +1463,14 @@ class KhiopsLocalRunner(KhiopsRunner):
             self._samples_dir_checked = True
         return self._samples_dir
 
-    def raw_run(self, tool_name, command_line_args=None, use_mpi=True, trace=False):
+    def raw_run(
+        self,
+        tool_name,
+        command_line_args=None,
+        use_mpi=True,
+        trace=False,
+        system_settings=None,
+    ):
         """Execute a Khiops tool with given command line arguments
 
         Parameters
@@ -1462,6 +1483,9 @@ class KhiopsLocalRunner(KhiopsRunner):
             Whether to execute the application with MPI
         trace : bool, default False
             If ``True`` print the trace of the process.
+        system_settings: `SystemSettings`
+            Set of settings that must be taken into account
+            for this specific run
 
         Examples
         --------
@@ -1499,9 +1523,9 @@ class KhiopsLocalRunner(KhiopsRunner):
             print(f"Khiops execution call: {khiops_call}")
 
         # Build custom Khiops process environment
-        # which makes sure HOME is defined and set
+        # which makes sure for example HOME is defined and set
         # according to khiops_env's KHIOPS_MPI_HOME
-        khiops_env = _build_khiops_process_environment()
+        khiops_env = _build_khiops_process_environment(system_settings)
 
         # Execute the process
         with subprocess.Popen(
@@ -1524,11 +1548,15 @@ class KhiopsLocalRunner(KhiopsRunner):
         scenario_path,
         command_line_options,
         trace,
+        system_settings,
     ):
         # Execute the tool
         khiops_args = command_line_options.build_command_line_options(scenario_path)
         stdout, stderr, return_code = self.raw_run(
-            tool_name, command_line_args=khiops_args, trace=trace
+            tool_name,
+            command_line_args=khiops_args,
+            trace=trace,
+            system_settings=system_settings,
         )
 
         return return_code, stdout, stderr

--- a/khiops/extras/docker.py
+++ b/khiops/extras/docker.py
@@ -103,6 +103,7 @@ class KhiopsDockerRunner(KhiopsRunner):
         scenario_path,
         command_line_options,
         trace,
+        system_settings,
     ):
         # Check arguments
         if command_line_options.output_scenario_path:

--- a/khiops/sklearn/estimators.py
+++ b/khiops/sklearn/estimators.py
@@ -348,6 +348,18 @@ class KhiopsEstimator(ABC, BaseEstimator):
     def fit(self, X, y=None, **kwargs):
         """Fit the estimator
 
+        Parameters
+        ----------
+        X : :external:term:`array-like` of shape (n_samples, n_features_in) or dict
+            Training dataset. Either an :external:term:`array-like` or a ``dict``
+            specification for multi-table datasets (see :doc:`/multi_table_primer`).
+
+        y : :external:term:`array-like` of shape (n_samples,)
+            The target values.
+
+        max_cores : int, optional
+            Maximum number of CPU cores allocated and used for the training.
+
         Returns
         -------
         self : `KhiopsEstimator`
@@ -689,6 +701,8 @@ class KhiopsCoclustering(ClusterMixin, KhiopsEstimator):
             The column that contains the id of the instance.
         columns : list, optional
             The columns to be co-clustered. If not specified it uses all columns.
+        max_cores : int, optional
+            Maximum number of CPU cores allocated and used for the training.
 
         Returns
         -------
@@ -764,6 +778,7 @@ class KhiopsCoclustering(ClusterMixin, KhiopsEstimator):
             main_table_path,
             variables,
             coclustering_file_path,
+            max_cores=kwargs.get("max_cores"),
             log_file_path=train_log_file_path,
             trace=self.verbose,
         )
@@ -1179,7 +1194,25 @@ class KhiopsCoclustering(ClusterMixin, KhiopsEstimator):
         return self.model_.copy(), None
 
     def fit_predict(self, X, y=None, **kwargs):
-        """Performs clustering on X and returns result (instead of labels)"""
+        """Performs clustering on X and returns result (instead of labels)
+
+        Parameters
+        ----------
+        X : :external:term:`array-like` of shape (n_samples, n_features_in) or dict
+            Training dataset. Either an :external:term:`array-like` or a ``dict``
+            specification for multi-table datasets (see :doc:`/multi_table_primer`).
+
+        y : :external:term:`array-like` of shape (n_samples,)
+            The target values.
+
+        max_cores : int, optional
+            Maximum number of CPU cores allocated and used for the training.
+
+        Returns
+        -------
+        results : `numpy.array`
+        """
+
         return self.fit(X, y, **kwargs).predict(X)
 
 
@@ -1253,6 +1286,9 @@ class KhiopsSupervisedEstimator(KhiopsEstimator):
         y : :external:term:`array-like` of shape (n_samples,)
             The target values.
 
+        max_cores : int, optional
+            Maximum number of CPU cores allocated and used for the training.
+
         Returns
         -------
         self : `KhiopsSupervisedEstimator`
@@ -1314,7 +1350,7 @@ class KhiopsSupervisedEstimator(KhiopsEstimator):
     def _fit_train_model(self, ds, computation_dir, **kwargs):
         # Train the model with Khiops
         train_args, train_kwargs = self._fit_prepare_training_function_inputs(
-            ds, computation_dir
+            ds, computation_dir, **kwargs
         )
         report_file_path, model_kdic_file_path = self._fit_core_training_function(
             *train_args, **train_kwargs
@@ -1335,7 +1371,7 @@ class KhiopsSupervisedEstimator(KhiopsEstimator):
     def _fit_core_training_function(self, *args, **kwargs):
         """A wrapper to the khiops.core training function for the estimator"""
 
-    def _fit_prepare_training_function_inputs(self, ds, computation_dir):
+    def _fit_prepare_training_function_inputs(self, ds, computation_dir, **fit_kwargs):
         # Set output path files
         output_dir = self._get_output_dir(computation_dir)
         report_file_path = fs.get_child_path(
@@ -1374,7 +1410,8 @@ class KhiopsSupervisedEstimator(KhiopsEstimator):
             report_file_path,
         ]
 
-        # Build the optional parameters from a copy of the estimator parameters
+        # Build the optional parameters from a copy
+        # of the estimator initializer parameters
         kwargs = self.get_params()
 
         # Remove non core.api params
@@ -1403,6 +1440,10 @@ class KhiopsSupervisedEstimator(KhiopsEstimator):
         kwargs["log_file_path"] = log_file_path
         kwargs["trace"] = kwargs["verbose"]
         del kwargs["verbose"]
+
+        # Set the technical parameters
+        if "max_cores" in fit_kwargs:
+            kwargs["max_cores"] = fit_kwargs["max_cores"]
 
         return args, kwargs
 
@@ -1584,10 +1625,10 @@ class KhiopsPredictor(KhiopsSupervisedEstimator):
         assert isinstance(y_pred, (str, pd.DataFrame)), "Expected str or DataFrame"
         return y_pred
 
-    def _fit_prepare_training_function_inputs(self, ds, computation_dir):
+    def _fit_prepare_training_function_inputs(self, ds, computation_dir, **fit_kwargs):
         # Call the parent method
         args, kwargs = super()._fit_prepare_training_function_inputs(
-            ds, computation_dir
+            ds, computation_dir, **fit_kwargs
         )
 
         # Rename parameters to be compatible with khiops.core
@@ -1855,10 +1896,10 @@ class KhiopsClassifier(ClassifierMixin, KhiopsPredictor):
         # Check the pair related parameters
         _check_pair_parameters(self)
 
-    def _fit_prepare_training_function_inputs(self, ds, computation_dir):
+    def _fit_prepare_training_function_inputs(self, ds, computation_dir, **fit_kwargs):
         # Call the parent method
         args, kwargs = super()._fit_prepare_training_function_inputs(
-            ds, computation_dir
+            ds, computation_dir, **fit_kwargs
         )
 
         # Rename parameters to be compatible with khiops.core
@@ -1877,6 +1918,9 @@ class KhiopsClassifier(ClassifierMixin, KhiopsPredictor):
 
         y : :external:term:`array-like` of shape (n_samples,)
             The target values.
+
+        max_cores : int, optional
+            Maximum number of CPU cores allocated and used for the training.
 
         Returns
         -------
@@ -2199,6 +2243,9 @@ class KhiopsRegressor(RegressorMixin, KhiopsPredictor):
 
         y : :external:term:`array-like` of shape (n_samples,)
             The target values.
+
+        max_cores : int, optional
+            Maximum number of CPU cores allocated and used for the training.
 
         Returns
         -------
@@ -2606,6 +2653,9 @@ class KhiopsEncoder(TransformerMixin, KhiopsSupervisedEstimator):
         y : :external:term:`array-like` of shape (n_samples,)
             The target values.
 
+        max_cores : int, optional
+            Maximum number of CPU cores allocated and used for the training.
+
         Returns
         -------
         self : `KhiopsEncoder`
@@ -2616,10 +2666,10 @@ class KhiopsEncoder(TransformerMixin, KhiopsSupervisedEstimator):
 
     # pylint: enable=useless-super-delegation
 
-    def _fit_prepare_training_function_inputs(self, ds, computation_dir):
+    def _fit_prepare_training_function_inputs(self, ds, computation_dir, **fit_kwargs):
         # Call the parent method
         args, kwargs = super()._fit_prepare_training_function_inputs(
-            ds, computation_dir
+            ds, computation_dir, **fit_kwargs
         )
         # Rename encoder parameters, delete unused ones
         # to be compatible with khiops.core
@@ -2724,6 +2774,9 @@ class KhiopsEncoder(TransformerMixin, KhiopsSupervisedEstimator):
 
         y : :external:term:`array-like` of shape (n_samples,)
             The target values.
+
+        max_cores : int, optional
+            Maximum number of CPU cores allocated and used for the training.
 
         Returns
         -------

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2639,9 +2639,11 @@ class ScenarioWriterRunner(KhiopsRunner):
         self,
         task,
         task_args,
-        command_line_options,
+        command_line_options=None,
         trace=False,
         system_settings=None,
+        stdout_file_path="",
+        stderr_file_path="",
         force_ansi_scenario=False,
         **kwargs,
     ):
@@ -2677,6 +2679,7 @@ class ScenarioWriterRunner(KhiopsRunner):
         scenario_path,
         command_line_options,
         trace,
+        system_settings,
     ):
         return 0, "", ""
 

--- a/tests/test_sklearn.py
+++ b/tests/test_sklearn.py
@@ -709,7 +709,8 @@ class KhiopsSklearnParameterPassingTests(unittest.TestCase):
                             ("khiops.core", "train_coclustering"): {
                                 "log_file_path": os.path.join(
                                     cls.output_dir, "khiops_train_cc.log"
-                                )
+                                ),
+                                "max_cores": 62,
                             },
                             ("khiops.core", "simplify_coclustering"): {
                                 "max_part_numbers": {"SampleId": 2},
@@ -767,6 +768,7 @@ class KhiopsSklearnParameterPassingTests(unittest.TestCase):
                                 "group_target_value": False,
                                 "additional_data_tables": {},
                                 "keep_selected_variables_only": False,
+                                "max_cores": 63,
                             }
                         },
                         "predict": {
@@ -797,6 +799,7 @@ class KhiopsSklearnParameterPassingTests(unittest.TestCase):
                                 "max_parts": 5,
                                 "keep_selected_variables_only": False,
                                 "additional_data_tables": {},
+                                "max_cores": 65,
                             }
                         },
                         "predict": {
@@ -834,6 +837,7 @@ class KhiopsSklearnParameterPassingTests(unittest.TestCase):
                                 "numerical_recoding_method": "part Id",
                                 "pairs_recoding_method": "part Id",
                                 "additional_data_tables": {},
+                                "max_cores": 67,
                             }
                         },
                         "predict": {
@@ -1419,14 +1423,29 @@ class KhiopsSklearnParameterPassingTests(unittest.TestCase):
                             self.expected_kwargs.get(schema_type), source_type
                         )
                     )
+                    # the original object is a generator not a list
+                    expected_kwargs_list = list(expected_kwargs_list)
+                    # add the custom_kwargs parameters to the expected ones
+                    if (
+                        len(expected_kwargs_list)
+                        and custom_kwargs is not None
+                        and len(custom_kwargs)
+                    ):
+                        expected_kwargs_list[0].update(custom_kwargs)
+
                     special_kwarg_checkers = (
                         self.special_kwarg_checkers.get(estimator_type_key)
                         .get(estimator_method)
                         .get((module_name, function_name))
                     )
+                    union_of_initializer_params_and_method_params = kwargs
+                    if custom_kwargs is not None and len(custom_kwargs):
+                        union_of_initializer_params_and_method_params.update(
+                            custom_kwargs
+                        )
                     for expected_kwargs in expected_kwargs_list:
                         self._check_kwargs(
-                            kwargs,
+                            union_of_initializer_params_and_method_params,
                             expected_kwargs=expected_kwargs,
                             special_checkers=special_kwarg_checkers,
                         )
@@ -1453,6 +1472,9 @@ class KhiopsSklearnParameterPassingTests(unittest.TestCase):
                 "group_target_value": False,
                 "keep_selected_variables_only": False,
             },
+            custom_kwargs={
+                "max_cores": 63,
+            },
         )
 
     def test_parameter_transfer_classifier_fit_from_monotable_dataframe_with_df_y(
@@ -1478,6 +1500,9 @@ class KhiopsSklearnParameterPassingTests(unittest.TestCase):
                 "n_feature_parts": 3,
                 "group_target_value": False,
                 "keep_selected_variables_only": False,
+            },
+            custom_kwargs={
+                "max_cores": 63,
             },
         )
 
@@ -1546,6 +1571,9 @@ class KhiopsSklearnParameterPassingTests(unittest.TestCase):
                 "transform_type_numerical": "part_id",
                 "transform_type_pairs": "part_id",
             },
+            custom_kwargs={
+                "max_cores": 67,
+            },
         )
 
     def test_parameter_transfer_encoder_fit_from_monotable_dataframe_with_df_y(
@@ -1573,6 +1601,9 @@ class KhiopsSklearnParameterPassingTests(unittest.TestCase):
                 "transform_type_categorical": "part_id",
                 "transform_type_numerical": "part_id",
                 "transform_type_pairs": "part_id",
+            },
+            custom_kwargs={
+                "max_cores": 67,
             },
         )
 
@@ -1637,6 +1668,9 @@ class KhiopsSklearnParameterPassingTests(unittest.TestCase):
                 "n_feature_parts": 5,
                 "keep_selected_variables_only": False,
             },
+            custom_kwargs={
+                "max_cores": 65,
+            },
         )
 
     def test_parameter_transfer_regressor_fit_from_monotable_dataframe_with_df_y(
@@ -1657,6 +1691,9 @@ class KhiopsSklearnParameterPassingTests(unittest.TestCase):
                 "construction_rules": ["TableMode", "TableSelection"],
                 "n_feature_parts": 5,
                 "keep_selected_variables_only": False,
+            },
+            custom_kwargs={
+                "max_cores": 65,
             },
         )
 
@@ -1709,6 +1746,7 @@ class KhiopsSklearnParameterPassingTests(unittest.TestCase):
                     "columns": ("SampleId", "Pos", "Char"),
                     "id_column": "SampleId",
                     "max_part_numbers": {"SampleId": 2},
+                    "max_cores": 62,
                 }
             },
         )


### PR DESCRIPTION
- this technical parameter was not added to the estimator initializer to allow a different value per call

Fixes #605 and #585

---

### TODO Before Asking for a Review
- [x] Rebase your branch to the latest version of `main` (or `main-v10`)
- [x] Make sure all CI workflows are green
- [x] When adding a public feature/fix: Update the `Unreleased` section of `CHANGELOG.md` (no date)
- [x] Self-Review: Review "Files Changed" tab and fix any problems you find
- API Docs (only if there are changes in docstrings, rst files or samples):
  - [ ] Check the docs build **without** warning: see the log of the API Docs workflow
  - [ ] Check that your changes render well in HTML: download the API Docs artifact and open `index.html`
  - If there are any problems it is faster to iterate by [building locally the API Docs](../blob/main/doc/README.md#build-the-documentation)
